### PR TITLE
Replace RNAseq name to fix export (TMART-312)

### DIFF
--- a/grails-app/controllers/com/recomdata/transmart/data/association/RModulesController.groovy
+++ b/grails-app/controllers/com/recomdata/transmart/data/association/RModulesController.groovy
@@ -36,7 +36,7 @@ class RModulesController {
             "MIRNA_SEQ":        "mirnaseq",
             "RBM":              "rbm",
             "PROTEOMICS":       "protein",
-            "RNASEQ":           "rnaseq_cog",
+            "RNASEQ":           "rnaseqcog",
             "METABOLOMICS":     "metabolite",
             "acgh":             "acgh",
             "rnaseq":           "rnaseq"


### PR DESCRIPTION
Data type names containing an underscore make the export fail. This name has also to be replaced in transmart-core-db
