### PR TITLE
use log intensity instead of z-score for marker selection, using limma for statistics 

### DIFF
--- a/grails-app/controllers/com/recomdata/transmart/data/association/MarkerSelectionController.groovy
+++ b/grails-app/controllers/com/recomdata/transmart/data/association/MarkerSelectionController.groovy
@@ -46,26 +46,13 @@ class MarkerSelectionController {
 		String tableHeader = """\
 						<thead>
 						<tr>
-							<th>Gene Symbol</th>	
-							<th>Probe ID</th>
-							<th>Raw p-value</th>
-							<th>Bonferroni</th>
-							<th>Holm</th>
-							<th>Hochberg</th>
-							<th>SidakSS</th>
-							<th>SidakSD</th>
-							<th>BH</th>
-							<th>BY</th>
-							<th>t</th>
-							<th>t (permutation)</th>
-							<th>Raw P (permutation)</th>
-							<th>Adjusted P (permutation)</th>
-							<th>Rank</th>
-							<th>S1 Mean</th>
-							<th>S2 Mean</th>
-							<th>S1 SD</th>
-							<th>S2 SD</th>
-							<th>Fold Change (relative to S1)</th>
+							<th>Gene Symbol&nbsp&nbsp&nbsp&nbsp</th>	
+							<th>Probe ID&nbsp&nbsp&nbsp&nbsp</th>
+							<th>Log2(fold change) S2 vs S1&nbsp&nbsp&nbsp&nbsp</th>
+							<th>t&nbsp&nbsp&nbsp&nbsp</th>
+							<th>P-value&nbsp&nbsp&nbsp&nbsp</th>
+							<th>Adjusted P-value&nbsp&nbsp&nbsp&nbsp</th>
+							<th>B&nbsp&nbsp&nbsp&nbsp</th>
 						</tr>
 						</thead>
 						"""
@@ -93,19 +80,6 @@ class MarkerSelectionController {
 							<td>${resultArray[4]}</td>
 							<td>${resultArray[5]}</td>
 							<td>${resultArray[6]}</td>
-							<td>${resultArray[7]}</td>
-							<td>${resultArray[8]}</td>
-							<td>${resultArray[9]}</td>
-							<td>${resultArray[10]}</td>
-							<td>${resultArray[11]}</td>
-							<td>${resultArray[12]}</td>
-							<td>${resultArray[13]}</td>
-							<td>${resultArray[14]}</td>
-							<td>${resultArray[15]}</td>
-							<td>${resultArray[16]}</td>
-							<td>${resultArray[17]}</td>
-							<td>${resultArray[18]}</td>
-							<td>${resultArray[19]}</td>
 						</tr>
 						"""
 				

--- a/web-app/Rscripts/MarkerSelection/MarkerSelection.R
+++ b/web-app/Rscripts/MarkerSelection/MarkerSelection.R
@@ -35,7 +35,11 @@ aggregate.probes = FALSE
 	library(plyr)
 	library(multtest)
 	library(reshape2)
+  	library(limma)
 	
+  #The Multiple hypothesis correction method used for DE analysis
+	mhcMethod = "BH"
+  
 	#---------------------
 	#Prepare raw data.
 	
@@ -46,7 +50,8 @@ aggregate.probes = FALSE
 	mRNAData$PROBE.ID 		<- gsub("^\\s+|\\s+$", "",mRNAData$PROBE.ID)
 	mRNAData$GENE_SYMBOL 	<- gsub("^\\s+|\\s+$", "",mRNAData$GENE_SYMBOL)
 	mRNAData$PATIENT.ID   	<- gsub("^\\s+|\\s+$", "",mRNAData$PATIENT.ID)
-	
+
+  
     if (aggregate.probes) {
         # probe aggregation function adapted from dataBuilder.R to heatmap's specific data-formats
         mRNAData <- MS.probe.aggregation(mRNAData, collapseRow.method = "MaxMean", collapseRow.selectFewestMissing = TRUE)
@@ -86,145 +91,78 @@ aggregate.probes = FALSE
 	#---------------------
 	
 	#---------------------
-	#Perform multiple hypothesis testing.
-	print("MULTIPLE HYPOTHESIS TESTING");
+	#Fitting linear model with limma
+	print("LINEAR MODEL")
 	#Remove the gene symbol column.
 	coercedDataWithoutGroup <- data.matrix(subset(coercedData, select=-c(GENE_SYMBOL,PROBE.ID)))
 
-	#Get a vector representing our subsets.
-	classVector <- colnames(coercedDataWithoutGroup)
-	classVector <- gsub("^S1.*","0",classVector)
-	classVector <- gsub("^S2.*","1",classVector)
-	classVector <- as.numeric(classVector)
+	rownames(coercedDataWithoutGroup)=coercedData$PROBE.ID # Rownames have to bed added --Wei and Serge
 	
-	#Check the class vector to verify we have two subsets.
-	if(length(unique(classVector)) < 2) stop("||FRIENDLY||There is only one subset selected, please select two in order to run the comparative analysis.")
+	#Creating a named vector for mapping PROBE.ID to GENE.SYMBOL --Wei and Serge
+	gene.symbols=coercedData$GENE_SYMBOL
+	names(gene.symbols)=coercedData$PROBE.ID
+  
+	#Get the vectors representing our subsets.
+  # ... for S1
+	classVector_S2 <- colnames(coercedDataWithoutGroup)
+	classVector_S2 <- gsub("^S1.*","0",classVector_S2)
+	classVector_S2 <- gsub("^S2.*","1",classVector_S2)
+	classVector_S2 <- as.numeric(classVector_S2)
+  # ... for S2
+	classVector_S1 <- colnames(coercedDataWithoutGroup)
+	classVector_S1 <- gsub("^S1.*","1",classVector_S1)
+	classVector_S1 <- gsub("^S2.*","0",classVector_S1)
+	classVector_S1 <- as.numeric(classVector_S1) 
 	
-	#Generate the t statistic.
-	tTestStatistic <- mt.teststat(coercedDataWithoutGroup, classVector)
+	#Check the class vectors to verify we have two subsets.
+	if(length(unique(classVector_S1)) < 2) stop("||FRIENDLY||There is only one subset selected, please select two in order to run the comparative analysis.")
+	if(length(unique(classVector_S2)) < 2) stop("||FRIENDLY||There is only one subset selected, please select two in order to run the comparative analysis.")
 	
-	#Find the raw p-value using the test statistic.
-	rawp0 <- 2 * (1 - pnorm(abs(tTestStatistic)))
+	# Design matrix -- added by Wei and Serge
+	design <- cbind(S1=classVector_S1,S2=classVector_S2)
+	#design <- cbind(S1=1,S2=classVector_S2)
+  #print(design)
+  
+	##... and contrast matrix
+	contrast.matrix = makeContrasts(S1-S2, levels=design)
 	
-	#This is the list of all the procedures we use to generate adjusted p-values.
-	procs <- c("Bonferroni", "Holm", "Hochberg", "SidakSS", "SidakSD", "BH", "BY")
+  print(contrast.matrix)
 	
-	#Find the adjusted p-values
-	adjustedPValues <- mt.rawp2adjp(rawp0, procs)
+  # Linear model fitting --added by Wei and Serge
+	print("-lmFit")
+	fit <- lmFit(coercedDataWithoutGroup, design)
+	fit <- contrasts.fit(fit, contrast.matrix)
+	print("-eBayes")
+	fit <- eBayes(fit)
+	print("topTable ...")
 	
-	#Change the list to be in order of the original list.
-	adjustedPValues <- data.frame(round(adjustedPValues$adjp[order(adjustedPValues$index), ],5))
+	contr=1
+	top.fit = data.frame(
+	  ID=rownames(fit$coefficients), #Remove Dependence on limma version
+	  logFC=fit$coefficients[,contr],
+	  t=fit$t[,contr],
+	  P.Value=fit$p.value[,contr],
+	  adj.P.val=p.adjust(p=fit$p.value[,contr], method=mhcMethod),
+	  B=fit$lods[,contr]
+	)
 	
-	#Add the GENE_SYMBOL column back to our adjusted p-values matrix.
-	adjustedPValues$GENE_SYMBOL <- geneList
-	adjustedPValues$PROBE.ID <- probeList
+	top.fit.ranked.decr = top.fit[ order(top.fit$B, decreasing=T), ]
+	rownames(top.fit.ranked.decr) = NULL
 	
-	#Add the t score to the frame.
-	adjustedPValues$t <- tTestStatistic
+	top.fit.ranked.decr.filt = top.fit.ranked.decr[1:numberOfMarkers,]
+	topgenes = cbind(gene.symbols[top.fit.ranked.decr.filt$ID], top.fit.ranked.decr.filt)
+	colnames(topgenes) = c("GENE_SYMBOL", "PROBE.ID", "logFC", "t", "P.value", "adj.P.val", "B")
+	rownames(topgenes) = NULL
 	
-	#Merge the stats into the gene stats frame.
-	geneStatsData <- merge(geneStatsData,adjustedPValues,by=c('GENE_SYMBOL','PROBE.ID'))
-	#---------------------
+	#End Linear model fitting
 	
-	#---------------------
-	#PERMUTATION TESTING
-	print("PERMUTATION TESTING");
-	#Do permutation testing to get p-values, and adjusted values.
-	permTesting <- mt.maxT(coercedDataWithoutGroup, classVector, B = numberOfPermutations)
-	
-	#Reorder the values based on the original index.
-	permTesting <- permTesting[order(permTesting$index),]
-	
-	#Add the gene column back.
-	permTesting$GENE_SYMBOL <- geneList
-	permTesting$PROBE.ID <- probeList
-	
-	#We don't need the index column anymore.
-	permTesting <- subset(permTesting, select = -c(index))
-	
-	#Rename the columns to show they are from the permutation testing.
-	colnames(permTesting) <- c('t.permutation','rawp.permutation','adjp.permutation','GENE_SYMBOL','PROBE.ID')
-	
-	#Merge the stats into the gene stats frame.
-	geneStatsData <- merge(geneStatsData,permTesting,by=c('GENE_SYMBOL','PROBE.ID'))
-	#---------------------
-	
-	#---------------------
-	#RANKING
-	print("RANKING");
-	#Order the data by absolute value of the t statistic.
-	geneStatsData <- geneStatsData[order(abs(geneStatsData$t),decreasing = TRUE), ]	
-	
-	#Only take the top X t-scores, or the whole list if we don't have X items.
-	GENELISTLENGTH <- length(geneStatsData$PROBE.ID)
-	
-	if(GENELISTLENGTH > numberOfMarkers) GENELISTLENGTH <- numberOfMarkers
-	
-	geneStatsData <- geneStatsData[1:GENELISTLENGTH,]
-	
-	#Add a rank column.
-	geneStatsData$RANK <- 1:nrow(geneStatsData)
-	#---------------------	
-	
-	#---------------------
-	#MEAN/SD
-	print("MEAN/SD");
-	
-	#We don't need to rank the MEAN/SD on all the data, just the top X probes. Cut the list based on the probes in the ranked data frame.
-	if (aggregate.probes) {
-    rankCutmRNAData <- subset(mRNAData, GENE_SYMBOL %in% geneStatsData$GENE_SYMBOL)
-  } else {
-    rankCutmRNAData <- subset(mRNAData, PROBE.ID %in% geneStatsData$PROBE.ID)
-  }
-
-	#Get the list of distinct subsets.
-	distinctSubsetNames <- unique(mRNAData$SUBSET)	
-	
-	#Get our S1/S2 data frames.
-	S1Frame <- rankCutmRNAData[which(rankCutmRNAData$SUBSET == distinctSubsetNames[1]),c('GENE_SYMBOL','PROBE.ID','VALUE')]
-	S2Frame <- rankCutmRNAData[which(rankCutmRNAData$SUBSET == distinctSubsetNames[2]),c('GENE_SYMBOL','PROBE.ID','VALUE')]
-	
-	#Calculate Means.
-	S1Mean <- ddply(S1Frame,.(PROBE.ID,GENE_SYMBOL),function(df)mean(df$VALUE))
-	S2Mean <- ddply(S2Frame,.(PROBE.ID,GENE_SYMBOL),function(df)mean(df$VALUE))
-	
-	#Calculate SD.
-	S1SD <- ddply(S1Frame,.(PROBE.ID,GENE_SYMBOL),function(df)sd(df$VALUE))
-	S2SD <- ddply(S2Frame,.(PROBE.ID,GENE_SYMBOL),function(df)sd(df$VALUE))
-	
-	#Add column names for means.
-	colnames(S1Mean) <- c('PROBE.ID','GENE_SYMBOL','S1.Mean')
-	colnames(S2Mean) <- c('PROBE.ID','GENE_SYMBOL','S2.Mean')
-	
-	#Add column names for SD.
-	colnames(S1SD) <- c('PROBE.ID','GENE_SYMBOL','S1.SD')
-	colnames(S2SD) <- c('PROBE.ID','GENE_SYMBOL','S2.SD')
-	
-	#Merge the means back in.
-	geneStatsData <- merge(geneStatsData,S1Mean,by=c('GENE_SYMBOL','PROBE.ID'))
-	geneStatsData <- merge(geneStatsData,S2Mean,by=c('GENE_SYMBOL','PROBE.ID'))
-	
-	#Merge the SD back in.
-	geneStatsData <- merge(geneStatsData,S1SD,by=c('GENE_SYMBOL','PROBE.ID'))
-	geneStatsData <- merge(geneStatsData,S2SD,by=c('GENE_SYMBOL','PROBE.ID'))
-	#---------------------		
-
-	#FOLD CHANGE
-    print("Calculating estimation of fold change relative to S1, using base2 exponentiation as zscore are calculated from log2 values");
-    geneStatsData$FoldChange.relative.to.S1 <- ifelse ((geneStatsData$S1.Mean >= geneStatsData$S2.Mean),
-        -1*2^(geneStatsData$S1.Mean - geneStatsData$S2.Mean),
-        2^(geneStatsData$S2.Mean - geneStatsData$S1.Mean))
-
 	#HEATMAP
-
-	#Get a copy of the data.
-	shortGeneStatsData <- geneStatsData
-	
-	#Add a column which tells us if the gene had a positive or negative t-score.
-	shortGeneStatsData$positive <- shortGeneStatsData$t > 0
-	
 	#We need to generate a heatmap with the top 100 markers. First we merge the t-scores back in with the original data.
-	heatmapData <- merge(coercedData,shortGeneStatsData,by=c('GENE_SYMBOL','PROBE.ID'))
+	#heatmapData <- merge(coercedData,shortGeneStatsData,by=c('GENE_SYMBOL','PROBE.ID'))
+	heatmapData <- merge(coercedData,topgenes,by=c('GENE_SYMBOL','PROBE.ID'))
+	
+	#Add a column which tells us if t score is positive
+	heatmapData$positive <- heatmapData$t > 0
 	
 	#We want to show the positive t scores in descending order, then the negative t scores in ascending order.
 	positiveHeatmapData <- heatmapData[which(heatmapData$positive == TRUE),]
@@ -233,43 +171,47 @@ aggregate.probes = FALSE
 	#Order the data by absolute value of the t statistic.
 	positiveHeatmapData <- positiveHeatmapData[order(positiveHeatmapData$t), ]	
 	negativeHeatmapData <- negativeHeatmapData[order(negativeHeatmapData$t,decreasing = TRUE), ]	
-
+	
 	#Put all the data together.
 	finalHeatmapData <- rbind(negativeHeatmapData,positiveHeatmapData)
+	
 
-    # The PROBE.ID column needs to have the values from GENE_SYMBOL concatenated as a suffix,
-    # but only if the latter does not contain a private value (which means that the biomarker was not present in any of the dictionaries)
-    rowsToConcatenate <- grep("^PRIVATE:", finalHeatmapData$GENE_SYMBOL, invert = TRUE)
-    finalHeatmapData$PROBE.ID[rowsToConcatenate] <- paste(finalHeatmapData$PROBE.ID[rowsToConcatenate], finalHeatmapData$GENE_SYMBOL[rowsToConcatenate],sep="_")
-
-	#Remove the t score and positive columns.
-	finalHeatmapData <- subset(finalHeatmapData, select = -c(GENE_SYMBOL,t,positive,S1.Mean,S2.Mean,S1.SD,S2.SD,FoldChange.relative.to.S1,RANK,rawp,Bonferroni,Holm,Hochberg,SidakSS,SidakSD,BH,BY,t.permutation,rawp.permutation,adjp.permutation))
+  #In case there is no GENE_SYMBOL annotation existing for given probe
+  if(length(which(finalHeatmapData$GENE_SYMBOL==""))>0)
+	  finalHeatmapData$GENE_SYMBOL[which(finalHeatmapData$GENE_SYMBOL=="")]="/"
+  
+	finalHeatmapData$GENE_SYMBOL <- paste(finalHeatmapData$PROBE.ID, finalHeatmapData$GENE_SYMBOL, sep='_')
+	#finalHeatmapData$GENE_SYMBOL <- paste(finalHeatmapData$GENE_SYMBOL, " (" , finalHeatmapData$PROBE.ID, ")",sep='')
+	finalHeatmapData$GENE_SYMBOL<-gsub("_\\s+$","",finalHeatmapData$GENE_SYMBOL, ignore.case = FALSE, perl = T)
+	# end
+	#finalHeatmapData <- subset(finalHeatmapData, select = -c(PROBE.ID,t,positive,S1.Mean,S2.Mean,S1.SD,S2.SD,FoldChange,RANK,rawp,BH,BY))
+	finalHeatmapData <- subset(finalHeatmapData, select = -c(PROBE.ID,t,positive,logFC,P.value,adj.P.val,B))
+	
 	
 	#Rename the first column to be "PROBE.ID".
 	colnames(finalHeatmapData)[1] <- 'PROBE.ID'
-	#---------------------
 	
-	#---------------------
-	#WRITE TO FILE
-	
-	#We need MASS to dump the matrix to a file.
-	require(MASS)
 
-	#Before we write the CMS file we need to replace any empty genes with NA.
-	geneStatsData$GENE_SYMBOL[which(geneStatsData$GENE_SYMBOL=="")] <- NA
-	
-	#Write the file with the stats by gene. This will get read into the UI.
-	write.matrix(geneStatsData,output.file,sep = "\t")
-	
-	#Write the data file we will use for the heatmap.
-	write.matrix(finalHeatmapData,'heatmapdata',sep = "\t")
+# 	#---------------------
+ 	#WRITE TO FILE
+  #Before we write the CMS file we need to replace any empty genes with NA.
+  topgenes$GENE_SYMBOL[which(topgenes$GENE_SYMBOL=="")] <- NA
+
+
+  #Write the file with the stats by gene. This will get read into the UI.
+  write.table(topgenes,output.file,sep = "\t", , quote=F, row.names=F)
+
+  #Write the data file we will use for the heatmap.
+  write.table(finalHeatmapData,'heatmapdata',sep = "\t", quote=F, row.names=F)
 	#---------------------
 	
 	print("-------------------")
 	##########################################
 }
 
-MS.probe.aggregation <- function(mRNAData, collapseRow.method, collapseRow.selectFewestMissing, output.file = "aggregated_data.txt") {
+MS.probe.aggregation <- function(mRNAData, collapseRow.method,
+                                 collapseRow.selectFewestMissing, 
+                                 output.file = "aggregated_data.txt") {
     library(WGCNA)
     
     #remove SUBSET column
@@ -281,56 +223,72 @@ MS.probe.aggregation <- function(mRNAData, collapseRow.method, collapseRow.selec
     castedData <- data.frame(dcast(meltedData, PROBE.ID + GENE_SYMBOL ~ PATIENT.ID))
 
     #Create a unique identifier column.
-    castedData$UNIQUE_ID <- paste(castedData$GENE_SYMBOL,castedData$PROBE.ID,sep="")
+    castedData$UNIQUE_ID <- paste(castedData$PROBE.ID, castedData$GENE_SYMBOL,sep="___")
 
     #Set the name of the rows to be the unique ID.
     rownames(castedData) = castedData$UNIQUE_ID
 
     if (nrow(castedData) <= 1) {
-        warning("Only one probe.id present in the data. Probe aggregation not possible.")
+        warning("Only one probe.id present in the data. Probe aggregation can not be performed.")
         return (mRNAData)
     }
-
-    #Run the collapse on a subset of the data by removing some columns.
-    finalData <- collapseRows(subset(castedData, select = -c(GENE_SYMBOL,PROBE.ID,UNIQUE_ID) ),
-                                  rowGroup = castedData$GENE_SYMBOL,
-                                  rowID = castedData$UNIQUE_ID,
-                                  method = collapseRow.method,
-                                  connectivityBasedCollapsing = TRUE,
-                                  methodFunction = NULL,
-                                  connectivityPower = 1,
-                                  selectFewestMissing = collapseRow.selectFewestMissing,
-                                  thresholdCombine = NA)
-
-    #Coerce the data into a data frame.
-    finalData=data.frame(finalData$group2row, finalData$datETcollapsed)
-
-    #Rename the columns, the selected row_id is the unique_id.
-    colnames(finalData)[2] <- 'UNIQUE_ID'
-
-    #Merge the probe.id back in.
-    finalData <- merge(finalData,castedData[c('UNIQUE_ID','PROBE.ID')],by=c('UNIQUE_ID'))
-
-    #Remove the unique_id and selected row ID column.
-    finalData <- subset(finalData, select = -c(UNIQUE_ID))
-
-    #Melt the data back.
-    finalData <- melt(finalData)
-
-    #Set the column names again.
-    colnames(finalData) <- c("GENE_SYMBOL","PROBE.ID","PATIENT.ID","VALUE")
-
-    #When we convert to a data frame the numeric columns get an x in front of them. Remove them here.
-    finalData$PATIENT.ID <- sub("^X","",finalData$PATIENT.ID)
-
-    #Return relevant columns
-    finalData <- finalData[,c("PATIENT.ID","VALUE","PROBE.ID","GENE_SYMBOL")]
     
-    finalData$SUBSET<-finalData$PATIENT.ID
-    finalData$SUBSET[grep("^S1_|_S1_|_S1$",finalData$SUBSET)]<-"S1"
-    finalData$SUBSET[grep("^S2_|_S2_|_S2$",finalData$SUBSET)]<-"S2"
+    #Input expression matrix for collapseRows function
+    datET = subset(castedData, select = -c(GENE_SYMBOL,PROBE.ID,UNIQUE_ID))
 
-    write.table(finalData, file = output.file, sep = "\t", row.names = FALSE)
+    GENE_SYMBOL = as.vector(castedData$GENE_SYMBOL)
+    UNIQUE_ID = as.vector(castedData$UNIQUE_ID)
+    rownames(datET) = UNIQUE_ID
 
-    finalData
+
+     #Run the collapsing on a subset of the data by removing some columns.
+     finalData <- collapseRows( datET = datET,
+                                rowGroup = GENE_SYMBOL,
+                                rowID = UNIQUE_ID,
+                                method = collapseRow.method,
+                                connectivityBasedCollapsing = TRUE,
+                                methodFunction = NULL,
+                                connectivityPower = 1,
+                                selectFewestMissing = collapseRow.selectFewestMissing,
+                                thresholdCombine = NA
+                                )
+
+      #Coerce the data into a data frame.
+      finalData=data.frame(finalData$group2row, finalData$datETcollapsed)
+
+      #Rename the columns, the selected row_id is the unique_id.
+      colnames(finalData)[2] <- 'UNIQUE_ID'
+ 
+      #Merge the probe.id and gene symbol back in and remove the group and unique_id columns.
+      matrix_annot = matrix(unlist(strsplit(as.vector(finalData$UNIQUE_ID), split="___")), ncol=2, byrow=T)
+      colnames(matrix_annot) = c("PROBE.ID", "GENE_SYMBOL")
+      finalData = cbind(matrix_annot, finalData)
+      finalData = subset(finalData, select=-c(group, UNIQUE_ID))
+
+
+      #Melt the data back into the initial format.
+      finalData <- melt(finalData)
+
+  
+      #Set the column names again.
+      colnames(finalData) <- c("PROBE.ID","GENE_SYMBOL","PATIENT.ID","VALUE")
+
+
+      #When we convert to a data frame the numeric columns get an x in front of them. Remove them here.
+      finalData$PATIENT.ID <- sub("^X","",finalData$PATIENT.ID)
+ 
+      #Return relevant columns
+      finalData <- finalData[,c("PATIENT.ID","VALUE","PROBE.ID","GENE_SYMBOL")]
+     
+      finalData$SUBSET<-finalData$PATIENT.ID
+      finalData$SUBSET[grep("^S1_|_S1_|_S1$",finalData$SUBSET)]<-"S1"
+      finalData$SUBSET[grep("^S2_|_S2_|_S2$",finalData$SUBSET)]<-"S2"
+ 
+
+      write.table(finalData, file = output.file, sep = "\t", row.names = FALSE)
+
+      return(finalData)
 }
+
+
+

--- a/web-app/js/plugin/MarkerSelection.js
+++ b/web-app/js/plugin/MarkerSelection.js
@@ -77,7 +77,7 @@ MarkerSelectionView.prototype.get_form_params = function () {
 
         // get analysis constraints
         var constraints_json = this.get_analysis_constraints('MarkerSelection');
-        constraints_json['projections'] = ["zscore"];
+        constraints_json['projections'] = ["log_intensity"];
 
         formParameters['analysisConstraints'] = JSON.stringify(constraints_json);
 


### PR DESCRIPTION
some changes to the Rmodules of tranSMART to correct the error of using z-score for MarkerSelection work flow. Now the log intensity is used and the marker selection algorithm is improved (done by Serge Eifes in eTRIKS-UL team). This has been done for V1.1 but unfortunately not taken to 1.2. Many users have concern of the MarkerSelection work flow in the current 1.2 that gives “strange” results. This fix basically try to reproduce the results in V1.1(with some slight improvements).
