### PR TITLE
use log intensity instead of z-score for marker selection, use limma for statistics

### DIFF
--- a/grails-app/controllers/com/recomdata/transmart/data/association/MarkerSelectionController.groovy
+++ b/grails-app/controllers/com/recomdata/transmart/data/association/MarkerSelectionController.groovy
@@ -46,26 +46,13 @@ class MarkerSelectionController {
 		String tableHeader = """\
 						<thead>
 						<tr>
-							<th>Gene Symbol</th>	
-							<th>Probe ID</th>
-							<th>Raw p-value</th>
-							<th>Bonferroni</th>
-							<th>Holm</th>
-							<th>Hochberg</th>
-							<th>SidakSS</th>
-							<th>SidakSD</th>
-							<th>BH</th>
-							<th>BY</th>
-							<th>t</th>
-							<th>t (permutation)</th>
-							<th>Raw P (permutation)</th>
-							<th>Adjusted P (permutation)</th>
-							<th>Rank</th>
-							<th>S1 Mean</th>
-							<th>S2 Mean</th>
-							<th>S1 SD</th>
-							<th>S2 SD</th>
-							<th>Fold Change (relative to S1)</th>
+							<th>Gene Symbol&nbsp&nbsp&nbsp&nbsp</th>	
+							<th>Probe ID&nbsp&nbsp&nbsp&nbsp</th>
+							<th>Log2(fold change) S2 vs S1&nbsp&nbsp&nbsp&nbsp</th>
+							<th>t&nbsp&nbsp&nbsp&nbsp</th>
+							<th>P-value&nbsp&nbsp&nbsp&nbsp</th>
+							<th>Adjusted P-value&nbsp&nbsp&nbsp&nbsp</th>
+							<th>B&nbsp&nbsp&nbsp&nbsp</th>
 						</tr>
 						</thead>
 						"""
@@ -93,19 +80,6 @@ class MarkerSelectionController {
 							<td>${resultArray[4]}</td>
 							<td>${resultArray[5]}</td>
 							<td>${resultArray[6]}</td>
-							<td>${resultArray[7]}</td>
-							<td>${resultArray[8]}</td>
-							<td>${resultArray[9]}</td>
-							<td>${resultArray[10]}</td>
-							<td>${resultArray[11]}</td>
-							<td>${resultArray[12]}</td>
-							<td>${resultArray[13]}</td>
-							<td>${resultArray[14]}</td>
-							<td>${resultArray[15]}</td>
-							<td>${resultArray[16]}</td>
-							<td>${resultArray[17]}</td>
-							<td>${resultArray[18]}</td>
-							<td>${resultArray[19]}</td>
 						</tr>
 						"""
 				

--- a/web-app/js/plugin/MarkerSelection.js
+++ b/web-app/js/plugin/MarkerSelection.js
@@ -77,7 +77,7 @@ MarkerSelectionView.prototype.get_form_params = function () {
 
         // get analysis constraints
         var constraints_json = this.get_analysis_constraints('MarkerSelection');
-        constraints_json['projections'] = ["zscore"];
+        constraints_json['projections'] = ["log_intensity"];
 
         formParameters['analysisConstraints'] = JSON.stringify(constraints_json);
 


### PR DESCRIPTION
some changes to the Rmodules of tranSMART to correct the error of using z-score for MarkerSelection work flow. Now the log intensity is used and the marker selection algorithm is improved (done by Serge Eifes in eTRIKS-UL team). This has been done for V1.1 but unfortunately not taken to 1.2. Many users have concern of the MarkerSelection work flow in the current 1.2 that gives “strange” results. This fix basically try to reproduce the results in V1.1(with some slight improvements).
