### PR TITLE
Issues/ft1152 heatmap visualization improvements

### DIFF
--- a/web-app/Rscripts/Heatmap/HClusteredHeatmapLoader.R
+++ b/web-app/Rscripts/Heatmap/HClusteredHeatmapLoader.R
@@ -122,8 +122,7 @@ cluster.by.columns = TRUE
     n_remaining_sample<-ncol(mRNAData)
     if (is.null(color.range.clamps)) color.range.clamps = c(min(mRNAData), max(mRNAData))
     if (n_remaining_marker>1 & n_remaining_sample >1) {
-        plotHeatmap(mRNAData, colcolor, cluster.by.rows, cluster.by.columns, color.range.clamps, output.file, extension = "png")
-        plotHeatmap(mRNAData, colcolor, cluster.by.rows, cluster.by.columns, color.range.clamps, output.file, extension = "svg")
+        plotHeatmap(mRNAData, colcolor, cluster.by.rows, cluster.by.columns, color.range.clamps, output.file)
     } else {
         #Prepare the package to capture the image file.
         CairoPNG(file=paste(output.file,".png",sep=""),width=as.numeric(imageWidth),height=as.numeric(imageHeight),pointsize=as.numeric(pointsize))
@@ -134,7 +133,7 @@ cluster.by.columns = TRUE
     print("-------------------")
 }
 
-plotHeatmap <- function(data, colcolors, cluster.by.rows, cluster.by.columns, color.range.clamps, output.file = "Heatmap", extension = "png") {
+plotHeatmap <- function(data, colcolors, cluster.by.rows, cluster.by.columns, color.range.clamps, output.file = "Heatmap") {
     require(Cairo)
     require(gplots)
 
@@ -142,89 +141,91 @@ plotHeatmap <- function(data, colcolors, cluster.by.rows, cluster.by.columns, co
             ifelse(cluster.by.columns, "both", "row"),
             ifelse(cluster.by.columns, "column", "none"))
 
-    pxPerCell <- 15
+    onlyOneSubset <- length(unique(colcolors))==1
+    if (onlyOneSubset) { colcolors <- "white" }
+
+    # The Cairo graphical backend has a width and heigth resolution restriction which depends upon environment settings
+    # The number of pixels (width and heigth) for each boxplot's cell is therefore dependent on the max number of row or column cells
+    # These numbers were found experimentally to generate legible plots, but might need to be further reduced if problems occur
+    maxDim <- max(dim(data)[1], dim(data)[2])
+    if (maxDim < 250) {pxPerCell <- 30}
+    else if (maxDim < 500) {pxPerCell <- 25}
+    else if (maxDim < 1000) {pxPerCell <- 20}
+    else if (maxDim < 2000) {pxPerCell <- 15}
+    else {pxPerCell <- 10} # less than 10 pixels per cell makes the plot illegible
+
+    # all paramaters determining the sizes of elements in the heatmap scale with the set pxPerCell (eg. fontsizes, legendsizes)
     hmPars <- list(pointSize = pxPerCell / 1, labelPointSize = pxPerCell / 9)
-    if (nrow(data) < 30 || ncol(data) < 30) {
-        pxPerCell <- 40
-        hmPars <- list(pointSize = pxPerCell / 5, labelPointSize = pxPerCell / 10)
-    }
 
-    maxResolution <- 30000
-    if (nrow(data) > ncol(data) && nrow(data)*pxPerCell > maxResolution) {
-        pxPerCell <- maxResolution/nrow(data)
-        hmPars <- list(pointSize = pxPerCell / 1, labelPointSize = pxPerCell / 9)
-    } else if (ncol(data)*pxPerCell > maxResolution) {
-        pxPerCell <- maxResolution/ncol(data)
-        hmPars <- list(pointSize = pxPerCell / 1, labelPointSize = pxPerCell / 9)
-    }
-    mainHeight <- nrow(data) * pxPerCell
-    mainWidth <- ncol(data) * pxPerCell
+    # The heatmap is split into a grid for each of its elements to be drawn in (see lmat argument in heatmap.2 function)
+    # the heatmap plot is split in 6 columns (left border, rows-dendrogram, rowcolors (not used), heatmap, labelStarts/legends, labelOverflow)
+    # the heatmap plot is split in 6 rows (top border, columns-dendrogram, columncolors/subsetLegend, heatmap, labelStarts/colLegend, labelOverflow)
+    # first, calculate labelOverflow sizes
+    letterSizeInCells <- 0.7
+    legendSizesInCells <- 20
+    rowLabelSizeMax <- max(0, max(nchar(colnames(data))) - (legendSizesInCells / letterSizeInCells))
+    colLabelSizeMax <- max(0, max(nchar(rownames(data))) - (legendSizesInCells / letterSizeInCells))
 
-    if (cluster.by.rows) {
-        leftMarginSize <- pxPerCell * log(nrow(data), base = 2)
-    } else {
-        leftMarginSize <- pxPerCell * 1
-    }
-    rightMarginSize <- pxPerCell * max(10, max(nchar(rownames(data))))
-    topMarginSize <- pxPerCell * 3
-    bottomMarginSize <- pxPerCell * max(10, max(nchar(colnames(data))))
-    if (cluster.by.columns) {
-        topDendrogramHeight <- pxPerCell * log(ncol(data), base = 2)
-    } else {
-        topDendrogramHeight <- pxPerCell * 1
-    }
+    # define the heatmap's grid sizes
+    columnSizes <- c(1, 5, 0, ncol(data), legendSizesInCells, letterSizeInCells * colLabelSizeMax) * pxPerCell
+    rowSizes <- c(1, 5, ifelse(onlyOneSubset, 0.5, 3), nrow(data), legendSizesInCells, letterSizeInCells * rowLabelSizeMax) * pxPerCell
+    totalWidth <- sum(columnSizes)
+    totalHeight <- sum(rowSizes)
+    hmCanvasColumnRatios <- columnSizes / totalWidth
+    hmCanvasRowRatios <- rowSizes / totalHeight
 
-    topSpectrumHeight <- rightMarginSize
+    tryCatch(CairoPNG(file = paste(output.file, ".png", sep=""), width = totalWidth,
+                      height = totalHeight, pointsize = hmPars$pointSize, units = "px"),
+             error = function(e) {stop("Cairo graphical backend could not be created. Your plot size is likely too big.")})
 
-    imageWidth <- leftMarginSize + mainWidth + rightMarginSize
-    imageHeight <- topSpectrumHeight + topDendrogramHeight + topMarginSize + mainHeight + bottomMarginSize
-
-    hmCanvasDiv <- list(xLeft = leftMarginSize / imageWidth, xMain = mainWidth / imageWidth, xRight = rightMarginSize / imageWidth,
-                        yTopLarge = topSpectrumHeight / imageHeight, yDendrogram = topDendrogramHeight / imageHeight, yTopSmall = topMarginSize / imageHeight,
-                        yMain = mainHeight / imageHeight, yBottom = bottomMarginSize / imageHeight)
-
-    if (extension == "svg") {
-        CairoSVG(file = paste(output.file,".svg",sep=""), width = imageWidth/200,
-                 height = imageHeight/200, pointsize = hmPars$pointSize*0.35)
-    } else {
-        CairoPNG(file = paste(output.file,".png",sep=""), width = imageWidth,
-                 height = imageHeight, pointsize = hmPars$pointSize)
-    }
     par(mar = c(0, 0, 0, 0))
+
+    noDifferentColors <- 800
+    plotColors <- greenred(noDifferentColors)
+
+    colorLegendPlot <- function() {
+        par(mar = c(6, 2, 6, 2))
+        sequenceOfBars <- rep(1, length(plotColors))
+        barplot(sequenceOfBars, main="Color mapping of Z score", cex.main = 2.2,
+                col = plotColors, space = 0, border = NA, axes = FALSE)
+        axis(1, at = c(1, noDifferentColors/2, noDifferentColors), labels = c(color.range.clamps[1], 0, color.range.clamps[2]), cex.axis = 3, lwd = 4, padj = 1)
+    }
 
     heatmap.2(data,
               ColSideColors = colcolors,
-              col = greenred(800),
-              breaks = seq(color.range.clamps[1], color.range.clamps[2], length.out = 800+1),
-              sepwidth=c(0,0),
-              margins=c(0, 0),
-              cexRow = hmPars$labelPointSize,
-              cexCol = hmPars$labelPointSize,
+              col = plotColors,
+              breaks = seq(color.range.clamps[1], color.range.clamps[2], length.out = 800 + 1),
+              sepwidth = c(0, 0),
+              margins = c(0, 0),
+              cexRow = 1.7, #hmPars$labelPointSize,
+              cexCol = 1.7, #hmPars$labelPointSize,
+              scale = "none",
               dendrogram = dendrogramOptions,
               Rowv = cluster.by.rows,
               Colv = cluster.by.columns,
-              scale = "none",
-              key = TRUE,
-              keysize = 0.001,
-              density.info = "histogram", # density.info=c("histogram","density","none")
+              density.info = "none", # histogram", # density.info=c("histogram","density","none")
               trace = "none",
-              # 1 is subset color bar, 2 is heatmap, 3 is row dendrogram, 4 is column dendrogram, 5 is color histogram
-              lmat = matrix(ncol = 3, byrow = TRUE, data = c(
-                  0, 5, 0,
-                  0, 4, 0,
-                  0, 1, 0,
-                  3, 2, 0,
-                  0, 0, 0)),
-              lwid = c(hmCanvasDiv$xLeft, hmCanvasDiv$xMain, hmCanvasDiv$xRight),
-              lhei = c(hmCanvasDiv$yTopLarge, hmCanvasDiv$yDendrogram, hmCanvasDiv$yTopSmall, hmCanvasDiv$yMain, hmCanvasDiv$yBottom))
+              lmat = matrix(ncol = 6, byrow = TRUE, data = c(
+                  # 1 is subset column color bar, 2 is heatmap, 3 is row-clustering, 4 is column-clustering, 5 is color histogram (turned off), 6 is custom color legend
+                  -1, -1, -1, -1, -1, -1,
+                  -1,  5, -1,  4, -1, -1,
+                  -1, -1, -1,  1, -1, -1,
+                  -1,  3, -1,  2, -1, -1,
+                  -1, -1, -1, -1,  6, -1,
+                  -1, -1, -1, -1, -1, -1)),
+              lhei = hmCanvasRowRatios,
+              lwid = hmCanvasColumnRatios,
+              key = FALSE,
+              extrafun = colorLegendPlot)
 
-    legend(x = 1 - hmCanvasDiv$xRight*0.93, y = 1,
-           legend = c("Subset 1","Subset 2"),
-           fill = c("orange","yellow"),
-           bg = "white", ncol = 1,
-           cex = topSpectrumHeight * 0.006,
-    )
-
+    # generate subset-legend if needed
+    if (!onlyOneSubset) {
+        legend(x = sum(hmCanvasColumnRatios[1:4]), y = 1 - sum(hmCanvasRowRatios[1:2]),
+               legend = c("Subset 1", "Subset 2"),
+               fill = c("orange", "yellow"),
+               bg = "white", horiz = TRUE,
+               cex = 1.2, xjust = 0, yjust = 1, bty = "n")
+    }
 
     dev.off()
 }

--- a/web-app/Rscripts/Heatmap/HClusteredHeatmapLoader.R
+++ b/web-app/Rscripts/Heatmap/HClusteredHeatmapLoader.R
@@ -49,21 +49,21 @@ cluster.by.columns = TRUE
         Plot.error.message("Your selection yielded an empty dataset,\nplease check your subset and biomarker selection."); return()
     }
 
-    # The GROUP column needs to have the values from GENE_SYMBOL concatenated as a suffix,
-    # but only if the latter does not contain a private value (which means that the biomarker was not present in any of the dictionaries)
-    mRNAData$GROUP <- as.character(mRNAData$GROUP)
-    rowsToConcatenate <- grep("^PRIVATE", mRNAData$GENE_SYMBOL, invert = TRUE)
-    mRNAData$GROUP[rowsToConcatenate] <- paste(mRNAData$GROUP[rowsToConcatenate], mRNAData$GENE_SYMBOL[rowsToConcatenate],sep="_")
-    mRNAData$GROUP <- as.factor(mRNAData$GROUP)
-
-    if (aggregate.probes) {
-        # probe aggregation function adapted from dataBuilder.R to heatmap's specific data-formats
-        mRNAData <- Heatmap.probe.aggregation(mRNAData, collapseRow.method = "MaxMean", collapseRow.selectFewestMissing = TRUE)
-    }
-
     #If we have to melt and cast, do it here, otherwise we make the group column the rownames
     if(meltData == TRUE)
     {
+        # The GROUP column needs to have the values from GENE_SYMBOL concatenated as a suffix,
+        # but only if the latter does not contain a private value (which means that the biomarker was not present in any of the dictionaries)
+        mRNAData$GROUP <- as.character(mRNAData$GROUP)
+        rowsToConcatenate <- grep("^PRIVATE", mRNAData$GENE_SYMBOL, invert = TRUE)
+        mRNAData$GROUP[rowsToConcatenate] <- paste(mRNAData$GROUP[rowsToConcatenate], mRNAData$GENE_SYMBOL[rowsToConcatenate],sep="_")
+        mRNAData$GROUP <- as.factor(mRNAData$GROUP)
+    
+        if (aggregate.probes) {
+            # probe aggregation function adapted from dataBuilder.R to heatmap's specific data-formats
+            mRNAData <- Heatmap.probe.aggregation(mRNAData, collapseRow.method = "MaxMean", collapseRow.selectFewestMissing = TRUE)
+        }
+
         #Trim the patient.id field.
         mRNAData$PATIENT_NUM <- gsub("^\\s+|\\s+$", "",mRNAData$PATIENT_NUM)
 

--- a/web-app/Rscripts/Heatmap/HClusteredHeatmapLoader.R
+++ b/web-app/Rscripts/Heatmap/HClusteredHeatmapLoader.R
@@ -75,18 +75,22 @@ cluster.by.columns = TRUE
 
         #When we convert to a data frame the numeric columns get an x in front of them. Remove them here.
         colnames(mRNAData) <- sub("^X","",colnames(mRNAData))
+        
+        #Set the name of the rows to be the names of the probes.
+        rownames(mRNAData) = mRNAData$GROUP
+
+        #Convert data to a integer matrix.
+        mRNAData <- data.matrix(subset(mRNAData, select = -c(GROUP)))
     } else {
         colnames(mRNAData) <- gsub("^\\s+|\\s+$","",colnames(mRNAData))
 
         #Use only unique row names. This unique should get rid of the case where we have multiple genes per probe. The values for the probes are all the same.
         mRNAData <- unique(mRNAData)
+        
+        #Convert data to a integer matrix.
+        rownames(mRNAData) <- mRNAData$PROBE.ID
+        mRNAData <- data.matrix(subset(mRNAData, select = -c(PROBE.ID)))
     }
-
-    #Set the name of the rows to be the names of the probes.
-    rownames(mRNAData) = mRNAData$GROUP
-
-    #Convert data to a integer matrix.
-    mRNAData <- data.matrix(subset(mRNAData, select = -c(GROUP)))
 
     #We can't draw a heatmap for a matrix with only 1 row.
     if(nrow(mRNAData)<2) stop("||FRIENDLY||R cannot plot a heatmap with only 1 Gene/Probe. Please check your variable selection and run again.")

--- a/web-app/Rscripts/Heatmap/HeatmapLoader.R
+++ b/web-app/Rscripts/Heatmap/HeatmapLoader.R
@@ -206,8 +206,8 @@ plotHeatmap <- function(data, colcolors, color.range.clamps, output.file = "Heat
               cexCol = 1.7, #hmPars$labelPointSize,
               scale = "none",
               dendrogram = "none",
-              Rowv = TRUE,
-              Colv = TRUE,
+              Rowv = NA,
+              Colv = NA,
               density.info = "none", # histogram", # density.info=c("histogram","density","none")
               trace = "none",
               lmat = matrix(ncol = 6, byrow = TRUE, data = c(

--- a/web-app/Rscripts/Heatmap/HeatmapLoader.R
+++ b/web-app/Rscripts/Heatmap/HeatmapLoader.R
@@ -47,23 +47,23 @@ aggregate.probes = FALSE
         Plot.error.message("Your selection yielded an empty dataset,\nplease check your subset and biomarker selection."); return()
     }
 
-    # The GROUP column needs to have the values from GENE_SYMBOL concatenated as a suffix,
-    # but only if the latter does not contain a private value
-    # (which means that the biomarker was not present in any of the dictionaries)
-    mRNAData$GROUP <- as.character(mRNAData$GROUP)
-    rowsToConcatenate <- grep("^PRIVATE", mRNAData$GENE_SYMBOL, invert = TRUE)
-    mRNAData$GROUP[rowsToConcatenate] <- paste(mRNAData$GROUP[rowsToConcatenate],
-            mRNAData$GENE_SYMBOL[rowsToConcatenate], sep="_")
-    mRNAData$GROUP <- as.factor(mRNAData$GROUP)
-
-    if (aggregate.probes) {
-        # probe aggregation function adapted from dataBuilder.R to heatmap's specific data-formats
-        mRNAData <- Heatmap.probe.aggregation(mRNAData, collapseRow.method = "MaxMean",
-                collapseRow.selectFewestMissing = TRUE)
-    }
-
     #If we have to melt and cast, do it here, otherwise we make the group column the rownames
     if(meltData == TRUE) {
+        # The GROUP column needs to have the values from GENE_SYMBOL concatenated as a suffix,
+        # but only if the latter does not contain a private value
+        # (which means that the biomarker was not present in any of the dictionaries)
+        mRNAData$GROUP <- as.character(mRNAData$GROUP)
+        rowsToConcatenate <- grep("^PRIVATE", mRNAData$GENE_SYMBOL, invert = TRUE)
+        mRNAData$GROUP[rowsToConcatenate] <- paste(mRNAData$GROUP[rowsToConcatenate],
+                                                   mRNAData$GENE_SYMBOL[rowsToConcatenate], sep="_")
+        mRNAData$GROUP <- as.factor(mRNAData$GROUP)
+    
+        if (aggregate.probes) {
+            # probe aggregation function adapted from dataBuilder.R to heatmap's specific data-formats
+            mRNAData <- Heatmap.probe.aggregation(mRNAData, collapseRow.method = "MaxMean",
+                                                  collapseRow.selectFewestMissing = TRUE)
+        }
+    
         #Trim the patient.id field.
         mRNAData$PATIENT_NUM <- gsub("^\\s+|\\s+$", "", mRNAData$PATIENT_NUM)
 

--- a/web-app/Rscripts/Heatmap/HeatmapLoader.R
+++ b/web-app/Rscripts/Heatmap/HeatmapLoader.R
@@ -75,18 +75,22 @@ aggregate.probes = FALSE
 
         #When we convert to a data frame the numeric columns get an x in front of them. Remove them here.
         colnames(mRNAData) <- sub("^X", "", colnames(mRNAData))
+        
+        #Set the name of the rows to be the names of the probes.
+        rownames(mRNAData) = mRNAData$GROUP
+        
+        #Convert data to a integer matrix.
+        mRNAData <- data.matrix(subset(mRNAData, select = -c(GROUP)))
     } else {
         colnames(mRNAData) <- gsub("^\\s+|\\s+$", "", colnames(mRNAData))
 
         #Use only unique row names. This unique should get rid of the case where we have multiple genes per probe. The values for the probes are all the same.
         mRNAData <- unique(mRNAData)
+        
+        #Convert data to a integer matrix.
+        rownames(mRNAData) <- mRNAData$PROBE.ID
+        mRNAData <- data.matrix(subset(mRNAData, select = -c(PROBE.ID)))
     }
-
-    #Set the name of the rows to be the names of the probes.
-    rownames(mRNAData) = mRNAData$GROUP
-
-    #Convert data to a integer matrix.
-    mRNAData <- data.matrix(subset(mRNAData, select = -c(GROUP)))
 
     #We can't draw a heatmap for a matrix with no rows.
     if(nrow(mRNAData) < 1) stop("||FRIENDLY||R cannot plot a heatmap with no Gene/Probe selected. Please check your variable selection and run again.")

--- a/web-app/Rscripts/Heatmap/HeatmapLoader.R
+++ b/web-app/Rscripts/Heatmap/HeatmapLoader.R
@@ -20,13 +20,13 @@
 
 Heatmap.loader <- function(
 input.filename,
-output.file ="Heatmap",
+output.file = "Heatmap",
 meltData = TRUE,
 imageWidth = 1200,
 imageHeight = 800,
 pointsize = 15,
 maxDrawNumber = Inf,
-color.range.clamps = c(-2.5,2.5),
+color.range.clamps = c(-2.5, 2.5),
 aggregate.probes = FALSE
 )
 {
@@ -39,192 +39,207 @@ aggregate.probes = FALSE
     library(ggplot2)
     library(reshape2)
     library(gplots)
-	
+
     #Pull the GEX data from the file.
     mRNAData <- data.frame(read.delim(input.filename, stringsAsFactors = FALSE))
 
     #We can't draw a heatmap if no data values are given
     if(nrow(mRNAData)<1) stop("||FRIENDLY||R cannot plot a heatmap when NO data is provided. Please check your variable selection and run again.")
 
-	#If we have to melt and cast, do it here, otherwise we make the group column the rownames
-	if(meltData == TRUE)
-	{
-    	# The GROUP column needs to have the values from GENE_SYMBOL concatenated as a suffix,
-        # but only if the latter does not contain a private value (which means that the biomarker was not present in any of the dictionaries)
-        mRNAData$GROUP <- as.character(mRNAData$GROUP)
-        rowsToConcatenate <- grep("^PRIVATE", mRNAData$GENE_SYMBOL, invert = TRUE)
-        mRNAData$GROUP[rowsToConcatenate] <- paste(mRNAData$GROUP[rowsToConcatenate], mRNAData$GENE_SYMBOL[rowsToConcatenate],sep="_")
-        mRNAData$GROUP <- as.factor(mRNAData$GROUP)
-    
-        if (aggregate.probes) {
-            # probe aggregation function adapted from dataBuilder.R to heatmap's specific data-formats
-            mRNAData <- Heatmap.probe.aggregation(mRNAData, collapseRow.method = "MaxMean", collapseRow.selectFewestMissing = TRUE)
-        }
-        
-		#Trim the patient.id field.
-		mRNAData$PATIENT_NUM <- gsub("^\\s+|\\s+$", "",mRNAData$PATIENT_NUM)
-	
-		#Melt the data, leaving 3 columns as the grouping fields.
-		meltedData <- melt(mRNAData, id=c("GROUP","PATIENT_NUM","GENE_SYMBOL"))
+    # The GROUP column needs to have the values from GENE_SYMBOL concatenated as a suffix,
+    # but only if the latter does not contain a private value
+    # (which means that the biomarker was not present in any of the dictionaries)
+    mRNAData$GROUP <- as.character(mRNAData$GROUP)
+    rowsToConcatenate <- grep("^PRIVATE", mRNAData$GENE_SYMBOL, invert = TRUE)
+    mRNAData$GROUP[rowsToConcatenate] <- paste(mRNAData$GROUP[rowsToConcatenate],
+            mRNAData$GENE_SYMBOL[rowsToConcatenate], sep="_")
+    mRNAData$GROUP <- as.factor(mRNAData$GROUP)
 
-		#Cast the data into a format that puts the ASSAY.ID in a column.
-		mRNAData <- data.frame(dcast(meltedData, GROUP ~ PATIENT_NUM))
-	  
-		#When we convert to a data frame the numeric columns get an x in front of them. Remove them here.
-		colnames(mRNAData) <- sub("^X","",colnames(mRNAData))
-		
-		  #Set the name of the rows to be the names of the probes.
-        rownames(mRNAData) = mRNAData$GROUP
-    
-        #Convert data to a integer matrix.
-        mRNAData <- data.matrix(subset(mRNAData, select = -c(GROUP)))
-	}
-	else
-	{	
-		colnames(mRNAData) <- gsub("^\\s+|\\s+$","",colnames(mRNAData))
-		
-		#Use only unique row names. This unique should get rid of the case where we have multiple genes per probe. The values for the probes are all the same.
-		mRNAData <- unique(mRNAData)
-		
-        #Convert data to a integer matrix.
-        rownames(mRNAData) <- mRNAData$PROBE.ID
-        mRNAData <- data.matrix(subset(mRNAData, select = -c(PROBE.ID)))
-	}
+    if (aggregate.probes) {
+        # probe aggregation function adapted from dataBuilder.R to heatmap's specific data-formats
+        mRNAData <- Heatmap.probe.aggregation(mRNAData, collapseRow.method = "MaxMean",
+                collapseRow.selectFewestMissing = TRUE)
+    }
 
-	#We can't draw a heatmap for a matrix with no rows.
-	if(nrow(mRNAData)<1) stop("||FRIENDLY||R cannot plot a heatmap with no Gene/Probe selected. Please check your variable selection and run again.")
-	if(ncol(mRNAData)<2) stop("||FRIENDLY||R cannot plot a heatmap with only 1 Patient data. Please check your variable selection and run again.")
+    #If we have to melt and cast, do it here, otherwise we make the group column the rownames
+    if(meltData == TRUE) {
+        #Trim the patient.id field.
+        mRNAData$PATIENT_NUM <- gsub("^\\s+|\\s+$", "", mRNAData$PATIENT_NUM)
 
-	#We can't draw a heatmap for a matrix with only 1 row (restriction of heatmap.2 function).
-	#Adding an extra dummy row with NA values, does the trick as they seems to be ignored in the plot and the density histogram
-	if(nrow(mRNAData)==1) {
-		mRNAData <- rbind(mRNAData, mRNAData[1,])
-		mRNAData[2,] = NA
-	}
+        #Melt the data, leaving 3 columns as the grouping fields.
+        meltedData <- melt(mRNAData, id = c("GROUP", "PATIENT_NUM", "GENE_SYMBOL"))
 
-# by Serge and Wei to filter a sub set and reorder markers
+        #Cast the data into a format that puts the ASSAY.ID in a column.
+        mRNAData <- data.frame(dcast(meltedData, GROUP ~ PATIENT_NUM))
 
-        num_markers<-dim(mRNAData)[1]                                                          # number of markers in the dataset
-        if (num_markers > maxDrawNumber) {                                                       # if more markers in the dataset, apply filter
-                sd_rows_mRNA<-apply (mRNAData,1,sd,na.rm=T)
-                mRNAData<-mRNAData[!is.na(sd_rows_mRNA),]                                      # remove markers where sd is NA
-                sd_rows_mRNA<-sd_rows_mRNA[!is.na(sd_rows_mRNA)]
-                indices_to_include <- order(sd_rows_mRNA,decreasing = T)[1:maxDrawNumber]     # filter by SD, keep only the top maxDrawNumber
-                mRNAData <- mRNAData[indices_to_include,]
-        }
+        #When we convert to a data frame the numeric columns get an x in front of them. Remove them here.
+        colnames(mRNAData) <- sub("^X", "", colnames(mRNAData))
+    } else {
+        colnames(mRNAData) <- gsub("^\\s+|\\s+$", "", colnames(mRNAData))
 
-        colcolor<-colnames(mRNAData)                                                           # assign colors for different subset
-        colcolor[grep("^S1_|_S1_|_S1$",colnames(mRNAData))]<-"orange"
-        colcolor[grep("^S2_|_S2_|_S2$",colnames(mRNAData))]<-"yellow"
+        #Use only unique row names. This unique should get rid of the case where we have multiple genes per probe. The values for the probes are all the same.
+        mRNAData <- unique(mRNAData)
+    }
 
-        mean_reorder<-rowMeans(mRNAData[,colcolor=="orange" ], na.rm = T)                      # reorder the data by rowmean of Subset 1
-        mRNAData<-mRNAData[order(mean_reorder,decreasing = T),]
-        rownames(mRNAData)<-gsub("_\\s+$","",rownames(mRNAData), ignore.case = FALSE, perl = T)                       # remove the _ at the end of the marker label
+    #Set the name of the rows to be the names of the probes.
+    rownames(mRNAData) = mRNAData$GROUP
+
+    #Convert data to a integer matrix.
+    mRNAData <- data.matrix(subset(mRNAData, select = -c(GROUP)))
+
+    #We can't draw a heatmap for a matrix with no rows.
+    if(nrow(mRNAData) < 1) stop("||FRIENDLY||R cannot plot a heatmap with no Gene/Probe selected. Please check your variable selection and run again.")
+    if(ncol(mRNAData) < 2) stop("||FRIENDLY||R cannot plot a heatmap with only 1 Patient data. Please check your variable selection and run again.")
+
+    #We can't draw a heatmap for a matrix with only 1 row (restriction of heatmap.2 function).
+    #Adding an extra dummy row with NA values, does the trick as they seems to be ignored in the plot and the density histogram
+    if(nrow(mRNAData) == 1) {
+        mRNAData <- rbind(mRNAData, mRNAData[1, ])
+        mRNAData[2, ] = NA
+    }
+
+    # by Serge and Wei to filter a sub set and reorder markers
+
+    num_markers<-dim(mRNAData)[1]  # number of markers in the dataset
+    if (num_markers > maxDrawNumber) {  # if more markers in the dataset, apply filter
+        sd_rows_mRNA <- apply (mRNAData, 1, sd, na.rm = T)
+        mRNAData <- mRNAData[!is.na(sd_rows_mRNA), ]  # remove markers where sd is NA
+        sd_rows_mRNA <- sd_rows_mRNA[!is.na(sd_rows_mRNA)]
+        indices_to_include <- order(sd_rows_mRNA, decreasing = T)[1:maxDrawNumber]  # filter by SD, keep only the top maxDrawNumber
+        mRNAData <- mRNAData[indices_to_include, ]
+    }
+
+    colcolor <- colnames(mRNAData)  # assign colors for different subset
+    colcolor[grep("^S1_|_S1_|_S1$", colnames(mRNAData))] <- "orange"
+    colcolor[grep("^S2_|_S2_|_S2$", colnames(mRNAData))] <- "yellow"
+
+    # reorder the data by rowmean of Subset 1
+    mean_reorder <- rowMeans(mRNAData[ , colcolor=="orange"], na.rm = T)
+    mRNAData <- mRNAData[order(mean_reorder, decreasing = T), ]
+    # remove the _ at the end of the marker label
+    rownames(mRNAData) <- gsub("_\\s+$", "", rownames(mRNAData), ignore.case = FALSE, perl = T)
 
 # end filter subset
 
 # check whether there is enough data to draw heatmap
-        n_remaining_marker<-nrow(mRNAData)
-        n_remaining_sample<-ncol(mRNAData)
-        if (is.null(color.range.clamps)) color.range.clamps = c(min(mRNAData), max(mRNAData))
-        if (n_remaining_marker>1 & n_remaining_sample >1) {
-            plotHeatmap(mRNAData, colcolor, color.range.clamps, output.file, extension = "png")
-            plotHeatmap(mRNAData, colcolor, color.range.clamps, output.file, extension = "svg")
-        } else {
+    n_remaining_marker <- nrow(mRNAData)
+    n_remaining_sample <- ncol(mRNAData)
+    if (is.null(color.range.clamps)) color.range.clamps = c(min(mRNAData), max(mRNAData))
+    if (n_remaining_marker > 1 & n_remaining_sample > 1) {
+        plotHeatmap(mRNAData, colcolor, color.range.clamps, output.file)
+    } else {
         #Prepare the package to capture the image file.
-            CairoPNG(file=paste(output.file,".png",sep=""),width=as.numeric(imageWidth),height=as.numeric(imageHeight),pointsize=as.numeric(pointsize))
-            tmp<-frame()
-            tmp2<-mtext ("not enough marker/samples to draw heatmap", cex=2)
-            print (tmp)
-            print (tmp2)
-            dev.off()
-        }
+        CairoPNG(file = paste(output.file, ".png", sep = ""), width = as.numeric(imageWidth),
+                height = as.numeric(imageHeight), pointsize = as.numeric(pointsize))
+        tmp <- frame()
+        tmp2 <- mtext("not enough marker/samples to draw heatmap", cex = 2)
+        print(tmp)
+        print(tmp2)
+        dev.off()
+    }
 
-
-	print("-------------------")
+    print("-------------------")
+    list(mRNAData)
 }
 
-plotHeatmap <- function(data, colcolors, color.range.clamps, output.file = "Heatmap", extension = "png") {
+plotHeatmap <- function(data, colcolors, color.range.clamps, output.file = "Heatmap") {
     require(Cairo)
     require(gplots)
 
-    pxPerCell <- 15
+    onlyOneSubset <- length(unique(colcolors))==1
+    if (onlyOneSubset) { colcolors <- "white" }
+
+    # The Cairo graphical backend has a width and height resolution restriction which depends upon environment settings
+    # The number of pixels (width and heigth) for each boxplot's cell is therefore dependent on the max number of row or column cells
+    # These numbers were found experimentally to generate legible plots, but might need to be further reduced if problems occur
+    maxDim <- max(dim(data)[1], dim(data)[2])
+    if (maxDim < 250) {pxPerCell <- 30}
+    else if (maxDim < 500) {pxPerCell <- 25}
+    else if (maxDim < 1000) {pxPerCell <- 20}
+    else if (maxDim < 2000) {pxPerCell <- 15}
+    else {pxPerCell <- 10} # less than 10 pixels per cell makes the plot illegible
+
+    # all paramaters determining the sizes of elements in the heatmap scale with the set pxPerCell (eg. fontsizes, legendsizes)
     hmPars <- list(pointSize = pxPerCell / 1, labelPointSize = pxPerCell / 9)
-    if (nrow(data) < 30 || ncol(data) < 30) {
-        pxPerCell <- 40
-        hmPars <- list(pointSize = pxPerCell / 5, labelPointSize = pxPerCell / 10)
-    }
 
-    maxResolution <- 30000
-    if (nrow(data) > ncol(data) && nrow(data)*pxPerCell > maxResolution) {
-        pxPerCell <- maxResolution/nrow(data)
-        hmPars <- list(pointSize = pxPerCell / 1, labelPointSize = pxPerCell / 9)
-    } else if (ncol(data)*pxPerCell > maxResolution) {
-        pxPerCell <- maxResolution/ncol(data)
-        hmPars <- list(pointSize = pxPerCell / 1, labelPointSize = pxPerCell / 9)
-    }
-    mainHeight <- nrow(data) * pxPerCell
-    mainWidth <- ncol(data) * pxPerCell
+    # The heatmap is split into a grid for each of its elements to be drawn in (see lmat argument in heatmap.2 function)
+    # the heatmap plot is split in 6 columns (left border, rows-dendrogram, rowcolors (not used), heatmap, labelStarts/legends, labelOverflow)
+    # the heatmap plot is split in 6 rows (top border, columns-dendrogram, columncolors/subsetLegend, heatmap, labelStarts/colLegend, labelOverflow)
+    # first, calculate labelOverflow sizes
+    letterSizeInCells <- 0.7
+    legendSizesInCells <- 20
+    rowLabelSizeMax <- max(0, max(nchar(colnames(data))) - (legendSizesInCells / letterSizeInCells))
+    colLabelSizeMax <- max(0, max(nchar(rownames(data))) - (legendSizesInCells / letterSizeInCells))
 
-    leftMarginSize <- pxPerCell * 1
-    rightMarginSize <- pxPerCell * max(10, max(nchar(rownames(data))))
-    topMarginSize <- pxPerCell * 3
-    bottomMarginSize <- pxPerCell * max(10, max(nchar(colnames(data))))
-    topSpectrumHeight <- rightMarginSize
+    # define the heatmap's grid sizes
+    columnSizes <- c(1, 3, 0, ncol(data), legendSizesInCells, letterSizeInCells * colLabelSizeMax) * pxPerCell
+    rowSizes <- c(1, 3, ifelse(onlyOneSubset, 0.5, 3), nrow(data), legendSizesInCells, letterSizeInCells * rowLabelSizeMax) * pxPerCell
+    totalWidth <- sum(columnSizes)
+    totalHeight <- sum(rowSizes)
+    hmCanvasColumnRatios <- columnSizes / totalWidth
+    hmCanvasRowRatios <- rowSizes / totalHeight
 
-    imageWidth <- leftMarginSize + mainWidth + rightMarginSize
-    imageHeight <- topSpectrumHeight + topMarginSize + mainHeight + bottomMarginSize
+    tryCatch(CairoPNG(file = paste(output.file, ".png", sep=""), width = totalWidth,
+                      height = totalHeight, pointsize = hmPars$pointSize, units = "px"),
+             error = function(e) {stop("Cairo graphical backend could not be created. Your plot size is likely too big.")})
 
-    hmCanvasDiv <- list(xLeft = leftMarginSize / imageWidth, xMain = mainWidth / imageWidth, xRight = rightMarginSize / imageWidth,
-                        yTopLarge = topSpectrumHeight / imageHeight, yTopSmall = topMarginSize / imageHeight,
-                        yMain = mainHeight / imageHeight, yBottom = bottomMarginSize / imageHeight)
-
-    if (extension == "svg") {
-        CairoSVG(file = paste(output.file,".svg",sep=""), width = imageWidth/200,
-                 height = imageHeight/200, pointsize = hmPars$pointSize*0.35)
-    } else {
-        CairoPNG(file = paste(output.file,".png",sep=""), width = imageWidth,
-                 height = imageHeight, pointsize = hmPars$pointSize)
-    }
     par(mar = c(0, 0, 0, 0))
+
+    noDifferentColors <- 800
+    plotColors <- greenred(noDifferentColors)
+
+    colorLegendPlot <- function() {
+        par(mar = c(6, 2, 6, 2))
+        sequenceOfBars <- rep(1, length(plotColors))
+        barplot(sequenceOfBars, main="Color mapping of Z score", cex.main = 2.2,
+                col = plotColors, space = 0, border = NA, axes = FALSE)
+        axis(1, at = c(1, noDifferentColors/2, noDifferentColors), labels = c(color.range.clamps[1], 0, color.range.clamps[2]), cex.axis = 3, lwd = 4, padj = 1)
+    }
+
     heatmap.2(data,
-              Rowv=NA,
-              Colv=NA,
               ColSideColors = colcolors,
-              col = greenred(800),
-              breaks = seq(color.range.clamps[1], color.range.clamps[2], length.out = 800+1),
-              sepwidth=c(0,0),
-              margins=c(0, 0),
-              cexRow = hmPars$labelPointSize,
-              cexCol = hmPars$labelPointSize,
+              col = plotColors,
+              breaks = seq(color.range.clamps[1], color.range.clamps[2], length.out = 800 + 1),
+              sepwidth = c(0, 0),
+              margins = c(0, 0),
+              cexRow = 1.7, #hmPars$labelPointSize,
+              cexCol = 1.7, #hmPars$labelPointSize,
               scale = "none",
               dendrogram = "none",
-              key = TRUE,
-              keysize = 0.001,
-              density.info = "histogram", # density.info=c("histogram","density","none")
+              Rowv = TRUE,
+              Colv = TRUE,
+              density.info = "none", # histogram", # density.info=c("histogram","density","none")
               trace = "none",
-              lmat = matrix(ncol = 3, byrow = TRUE, data = c( # 1 is subset color bar, 2 is heatmap, 5 is color histogram
-                  3, 5, 4,
-                  6, 1, 7,
-                  8, 2, 9,
-                  10, 11, 12)),
-              lwid = c(hmCanvasDiv$xLeft, hmCanvasDiv$xMain, hmCanvasDiv$xRight),
-              lhei = c(hmCanvasDiv$yTopLarge, hmCanvasDiv$yTopSmall, hmCanvasDiv$yMain, hmCanvasDiv$yBottom))
+              lmat = matrix(ncol = 6, byrow = TRUE, data = c(
+                  # 1 is subset column color bar, 2 is heatmap, 3 is row-clustering, 4 is column-clustering, 5 is color histogram (turned off), 6 is custom color legend
+                  -1, -1, -1, -1, -1, -1,
+                  -1,  5, -1,  4, -1, -1,
+                  -1, -1, -1,  1, -1, -1,
+                  -1,  3, -1,  2, -1, -1,
+                  -1, -1, -1, -1,  6, -1,
+                  -1, -1, -1, -1, -1, -1)),
+              lhei = hmCanvasRowRatios,
+              lwid = hmCanvasColumnRatios,
+              key = FALSE,
+              extrafun = colorLegendPlot)
 
-    legend(x = 1 - hmCanvasDiv$xRight*0.93, y = 1,
-           legend = c("Subset 1","Subset 2"),
-           fill = c("orange","yellow"),
-           bg = "white", ncol = 1,
-           cex = topSpectrumHeight * 0.006,
-    )
+    # generate subset-legend if needed
+    if (!onlyOneSubset) {
+        legend(x = sum(hmCanvasColumnRatios[1:4]), y = 1 - sum(hmCanvasRowRatios[1:2]),
+               legend = c("Subset 1", "Subset 2"),
+               fill = c("orange", "yellow"),
+               bg = "white", horiz = TRUE,
+               cex = 1.2, xjust = 0, yjust = 1, bty = "n")
+    }
 
     dev.off()
 }
 
-Heatmap.probe.aggregation <- function(mRNAData, collapseRow.method, collapseRow.selectFewestMissing, output.file = "aggregated_data.txt") {
-	library(WGCNA)
+Heatmap.probe.aggregation <-
+function(mRNAData, collapseRow.method, collapseRow.selectFewestMissing, output.file = "aggregated_data.txt") {
+    library(WGCNA)
 
-    meltedData <- melt(mRNAData, id=c("GROUP","GENE_SYMBOL","PATIENT_NUM"))
+    meltedData <- melt(mRNAData, id = c("GROUP", "GENE_SYMBOL", "PATIENT_NUM"))
 
     #Cast the data into a format that puts the PATIENT_NUM in a column.
     castedData <- data.frame(dcast(meltedData, GROUP + GENE_SYMBOL ~ PATIENT_NUM))
@@ -242,14 +257,14 @@ Heatmap.probe.aggregation <- function(mRNAData, collapseRow.method, collapseRow.
 
     #Run the collapse on a subset of the data by removing some columns.
     finalData <- collapseRows(subset(castedData, select = -c(GENE_SYMBOL,GROUP,UNIQUE_ID) ),
-                                  rowGroup = castedData$GENE_SYMBOL,
-                                  rowID = castedData$UNIQUE_ID,
-                                  method = collapseRow.method,
-                                  connectivityBasedCollapsing = TRUE,
-                                  methodFunction = NULL,
-                                  connectivityPower = 1,
-                                  selectFewestMissing = collapseRow.selectFewestMissing,
-                                  thresholdCombine = NA)
+            rowGroup = castedData$GENE_SYMBOL,
+            rowID = castedData$UNIQUE_ID,
+            method = collapseRow.method,
+            connectivityBasedCollapsing = TRUE,
+            methodFunction = NULL,
+            connectivityPower = 1,
+            selectFewestMissing = collapseRow.selectFewestMissing,
+            thresholdCombine = NA)
 
     #Coerce the data into a data frame.
     finalData=data.frame(finalData$group2row, finalData$datETcollapsed)

--- a/web-app/Rscripts/Heatmap/KMeansHeatmap.R
+++ b/web-app/Rscripts/Heatmap/KMeansHeatmap.R
@@ -209,6 +209,8 @@ plotHeatmap <- function(data, rowLabels, colcolors, color.range.clamps, output.f
     }
 
     heatmap.2(data,
+              Rowv=NA,
+              Colv=NA,
               ColSideColors = colcolors,
               col = plotColors,
               breaks = seq(color.range.clamps[1], color.range.clamps[2], length.out = 800 + 1),


### PR DESCRIPTION
This mainly changes the visualization of all three heatmap analyses (vanilla, Kmeans clustering and Hierarchical Clustering). Their legends have been simplified and re-positioned, and some font and margin improvements have been made. Work done as part of TraIT's general TranSMART improvement.

In addition, this was developed over the course of some months on top of the master branch of The Hyve's Rmodules repository. The merge conflict with the Transmart Foundation's master branch caused some regression bugs and revealed some other minor bugs, which were addressed in this branch as well.

I tested each of the 4 analyses affected (Marker Selection makes use of the vanilla heatmap plot), and they show identical results (KMeans is non-deterministic, so I manually needed to set the seed) with the analyses run on the latest Rmodules of the Transmart Foundation.

@weiguUL Could you perhaps validate my changes and possibly honour this pull request?