### PR TITLE
Z-score on the fly calculation

### DIFF
--- a/grails-app/views/plugin/HClust.gsp
+++ b/grails-app/views/plugin/HClust.gsp
@@ -41,6 +41,10 @@
                 <input type="checkbox" id="chkClusterColumns" name="doClusterColumns" checked="true">
                 <span>Apply clustering for columns</span>
             </div>
+            <div>
+                <input type="checkbox" id="chkCalculateZscore" name="calculateZscore">
+                <span>Calculate z-score on the fly</span>
+            </div>
             <input type="button" value="Run" onClick="hierarchicalClusteringView.submit_job(this.form);" class="runAnalysisBtn">
         </fieldset>
     </form>

--- a/grails-app/views/plugin/Heatmap.gsp
+++ b/grails-app/views/plugin/Heatmap.gsp
@@ -37,6 +37,10 @@
                 <input type="checkbox" id="chkGroupBySubject" name="doGroupBySubject">
                 <span>Group by subject (instead of node) for multiple nodes</span>
             </div>
+            <div>
+                <input type="checkbox" id="chkCalculateZscore" name="calculateZscore">
+                <span>Calculate z-score on the fly</span>
+            </div>
             <input type="button" value="Run" onClick="heatMapView.submit_job(this.form);" class="runAnalysisBtn">
         </fieldset>
     </form>

--- a/grails-app/views/plugin/KClust.gsp
+++ b/grails-app/views/plugin/KClust.gsp
@@ -36,6 +36,10 @@
         </fieldset>
 
         <fieldset class="toolFields">
+            <div>
+                <input type="checkbox" id="chkCalculateZscore" name="calculateZscore">
+                <span>Calculate z-score on the fly</span>
+            </div>
             <input type="button" value="Run" onClick="kmeansClustering.submit_job(this.form);" class="runAnalysisBtn">
         </fieldset>
 

--- a/grails-app/views/plugin/MarkerSelection.gsp
+++ b/grails-app/views/plugin/MarkerSelection.gsp
@@ -38,6 +38,10 @@
                 <input type="checkbox" id="chkGroupBySubject" name="doGroupBySubject">
                 <span>Group by subject (instead of node) for multiple nodes</span>
             </div>
+            <div>
+                <input type="checkbox" id="chkCalculateZscore" name="calculateZscore">
+                <span>Calculate z-score on the fly</span>
+            </div>
             <input type="button" value="Run" onClick="markerSelectionView.submit_job(this.form);" class="runAnalysisBtn">
         </fieldset>
     </form>

--- a/grails-app/views/plugin/PCA.gsp
+++ b/grails-app/views/plugin/PCA.gsp
@@ -34,6 +34,10 @@
                 <input type="checkbox" id="chkUseExperimentAsVariable" name="doUseExperimentAsVariable">
                 <span>Use experiment/node as variable instead of probe (multiple nodes only)</span>
             </div>
+            <div>
+                <input type="checkbox" id="chkCalculateZscore" name="calculateZscore">
+                <span>Calculate z-score on the fly</span>
+            </div>
             <input type="button" value="Run" onClick="pcaView.submit_job(this.form);" class="runAnalysisBtn">
         </fieldset>
 

--- a/src/groovy/jobs/Heatmap.groovy
+++ b/src/groovy/jobs/Heatmap.groovy
@@ -24,7 +24,8 @@ class Heatmap extends HighDimensionalOnlyJob {
         String createHeatmap = '''Heatmap.loader(
                             input.filename = '$inputFileName',
                             aggregate.probes = '$divIndependentVariableprobesAggregation' == 'true'
-                            ${ txtMaxDrawNumber ? ", maxDrawNumber  = as.integer('$txtMaxDrawNumber')" : ''}
+                            ${ txtMaxDrawNumber ? ", maxDrawNumber  = as.integer('$txtMaxDrawNumber')" : ''},
+                            calculateZscore = '$calculateZscore'
                             )'''
 
         [ source, createHeatmap ]

--- a/src/groovy/jobs/HierarchicalClustering.groovy
+++ b/src/groovy/jobs/HierarchicalClustering.groovy
@@ -26,7 +26,8 @@ class HierarchicalClustering extends HighDimensionalOnlyJob {
                             aggregate.probes = '$divIndependentVariableprobesAggregation' == 'true',
                             cluster.by.rows = '$doClusterRows' == 'true',
                             cluster.by.columns = '$doClusterColumns' == 'true',
-                            ${ txtMaxDrawNumber ? ", maxDrawNumber  = as.integer('$txtMaxDrawNumber')" : ''}
+                            ${ txtMaxDrawNumber ? ", maxDrawNumber  = as.integer('$txtMaxDrawNumber')" : ''},
+                            calculateZscore = '$calculateZscore'
                             )'''
 
         [ source, createHeatmap ]

--- a/src/groovy/jobs/KMeansClustering.groovy
+++ b/src/groovy/jobs/KMeansClustering.groovy
@@ -27,7 +27,8 @@ class KMeansClustering extends HighDimensionalOnlyJob {
                             input.filename   = '$inputFileName',
                             aggregate.probes = '$divIndependentVariableprobesAggregation' == 'true',
                             clusters.number  = as.integer('$txtClusters'),
-                            ${ txtMaxDrawNumber ? ", maxDrawNumber  = as.integer('$txtMaxDrawNumber')" : ''}
+                            ${ txtMaxDrawNumber ? ", maxDrawNumber  = as.integer('$txtMaxDrawNumber')" : ''},
+                            calculateZscore = '$calculateZscore'
                             )'''
 
         [ source, createHeatmap ]

--- a/src/groovy/jobs/MarkerSelection.groovy
+++ b/src/groovy/jobs/MarkerSelection.groovy
@@ -26,7 +26,8 @@ class MarkerSelection extends HighDimensionalOnlyJob {
         String markerSelectionLoad = '''MS.loader(
                             input.filename = \'$inputFileName\',
                             numberOfMarkers = as.integer(\'$txtNumberOfMarkers\'),
-                            aggregate.probes = '$divIndependentVariableprobesAggregation' == 'true')'''
+                            aggregate.probes = '$divIndependentVariableprobesAggregation' == 'true',
+                            calculateZscore = '$calculateZscore')'''
         // set path to heatmap png file generator
         String sourceHeatmap = 'source(\'$pluginDirectory/Heatmap/HeatmapLoader.R\')'
         // generate the actual heatmap png picture

--- a/src/groovy/jobs/PCA.groovy
+++ b/src/groovy/jobs/PCA.groovy
@@ -23,6 +23,7 @@ class PCA extends HighDimensionalOnlyJob {
                 '''PCA.loader(
                 input.filename='$inputFileName',
                 aggregate.probes = '$divIndependentVariableprobesAggregation' == 'true',
+                calculateZscore = '$calculateZscore'
                 )''' ]
 
     @Override

--- a/web-app/Rscripts/Heatmap/HClusteredHeatmapLoader.R
+++ b/web-app/Rscripts/Heatmap/HClusteredHeatmapLoader.R
@@ -29,7 +29,8 @@ maxDrawNumber = Inf,
 color.range.clamps = c(-2.5,2.5),
 aggregate.probes = FALSE,
 cluster.by.rows = TRUE,
-cluster.by.columns = TRUE
+cluster.by.columns = TRUE,
+calculateZscore = FALSE
 )
 {
 

--- a/web-app/Rscripts/Heatmap/HeatmapLoader.R
+++ b/web-app/Rscripts/Heatmap/HeatmapLoader.R
@@ -28,7 +28,8 @@ pointsize = 15,
 maxDrawNumber = Inf,
 color.range.clamps = c(-2.5,2.5),
 aggregate.probes = FALSE,
-calculateZscore = FALSE
+calculateZscore = FALSE,
+zscore.file = "zscores.txt"
 )
 {
 
@@ -40,6 +41,7 @@ calculateZscore = FALSE
     library(ggplot2)
     library(reshape2)
     library(gplots)
+    library(plyr)
 	
     #Pull the GEX data from the file.
     mRNAData <- data.frame(read.delim(input.filename, stringsAsFactors = FALSE))
@@ -47,6 +49,18 @@ calculateZscore = FALSE
     #We can't draw a heatmap if no data values are given
     if(nrow(mRNAData)<1) stop("||FRIENDLY||R cannot plot a heatmap when NO data is provided. Please check your variable selection and run again.")
 
+    if(calculateZscore){
+      mRNAData = ddply(mRNAData, "GROUP", transform, probe.md = median(VALUE, na.rm = TRUE))
+      mRNAData = ddply(mRNAData, "GROUP", transform, probe.sd = sd(VALUE, na.rm = TRUE))        
+      mRNAData$VALUE = with(mRNAData, ifelse(probe.sd == 0, 0,
+                                     (mRNAData$VALUE - mRNAData$probe.md) / mRNAData$probe.sd))
+      mRNAData$VALUE = with(mRNAData, ifelse(VALUE > 2.5, 2.5,
+                                      ifelse(VALUE < -2.5, -2.5, VALUE)))
+      mRNAData$VALUE = round(mRNAData$VALUE, 9)
+      mRNAData$probe.md = NULL
+      mRNAData$probe.sd = NULL
+      write.table(mRNAData,zscore.file,quote=F,sep="\t",row.names=F,col.names=T)
+    }
 	#If we have to melt and cast, do it here, otherwise we make the group column the rownames
 	if(meltData == TRUE)
 	{

--- a/web-app/Rscripts/Heatmap/HeatmapLoader.R
+++ b/web-app/Rscripts/Heatmap/HeatmapLoader.R
@@ -27,7 +27,8 @@ imageHeight = 800,
 pointsize = 15,
 maxDrawNumber = Inf,
 color.range.clamps = c(-2.5,2.5),
-aggregate.probes = FALSE
+aggregate.probes = FALSE,
+calculateZscore = FALSE
 )
 {
 

--- a/web-app/Rscripts/Heatmap/KMeansHeatmap.R
+++ b/web-app/Rscripts/Heatmap/KMeansHeatmap.R
@@ -28,7 +28,8 @@ imageHeight = 800,
 pointsize = 15,
 maxDrawNumber = Inf,
 color.range.clamps = c(-2.5,2.5),
-aggregate.probes = FALSE
+aggregate.probes = FALSE,
+calculateZscore = FALSE
 )
 {
     print("-------------------")

--- a/web-app/Rscripts/MarkerSelection/MarkerSelection.R
+++ b/web-app/Rscripts/MarkerSelection/MarkerSelection.R
@@ -23,7 +23,8 @@ input.filename,
 output.file ="CMS.TXT",
 numberOfPermutations = 5000,
 numberOfMarkers = 100,
-aggregate.probes = FALSE
+aggregate.probes = FALSE,
+calculateZscore = FALSE
 )
 {
 	##########################################

--- a/web-app/Rscripts/PCA/LoadPCA.R
+++ b/web-app/Rscripts/PCA/LoadPCA.R
@@ -23,7 +23,8 @@ input.filename,
 output.file ="PCA",
 aggregate.probes = FALSE,
 max.pcs.to.show = 10,
-calculateZscore = FALSE
+calculateZscore = FALSE,
+zscore.file = "zscores.txt"
 )
 {
 
@@ -33,7 +34,8 @@ calculateZscore = FALSE
 
     library(reshape2)
     library(Cairo)
-	library(ggplot2)
+  	library(ggplot2)
+  	library(plyr)
 
     #Prepare the package to capture the image file.
     CairoPNG(file=paste("PCA.png",sep=""),width=400,height=400)
@@ -46,6 +48,19 @@ calculateZscore = FALSE
 
     if (nrow(mRNAData)<1) stop("Input data is empty. Common causes: either the specified subset has no matching data in the selected node, or the gene/pathway is not present.")
 
+    if(calculateZscore){
+      mRNAData = ddply(mRNAData, "PROBE.ID", transform, probe.md = median(VALUE, na.rm = TRUE))
+      mRNAData = ddply(mRNAData, "PROBE.ID", transform, probe.sd = sd(VALUE, na.rm = TRUE))        
+      mRNAData$VALUE = with(mRNAData, ifelse(probe.sd == 0, 0,
+                                             (mRNAData$VALUE - mRNAData$probe.md) / mRNAData$probe.sd))
+      mRNAData$VALUE = with(mRNAData, ifelse(VALUE > 2.5, 2.5,
+                                             ifelse(VALUE < -2.5, -2.5, VALUE)))
+      mRNAData$VALUE = round(mRNAData$VALUE, 9)
+      mRNAData$probe.md = NULL
+      mRNAData$probe.sd = NULL
+      write.table(mRNAData,zscore.file,quote=F,sep="\t",row.names=F,col.names=T)
+    }
+    
     if (aggregate.probes) {
         # probe aggregation function adapted from dataBuilder.R to heatmap's specific data-formats
         mRNAData <- PCA.probe.aggregation(mRNAData, collapseRow.method = "MaxMean", collapseRow.selectFewestMissing = TRUE)

--- a/web-app/Rscripts/PCA/LoadPCA.R
+++ b/web-app/Rscripts/PCA/LoadPCA.R
@@ -22,7 +22,8 @@ PCA.loader <- function(
 input.filename,
 output.file ="PCA",
 aggregate.probes = FALSE,
-max.pcs.to.show = 10
+max.pcs.to.show = 10,
+calculateZscore = FALSE
 )
 {
 

--- a/web-app/js/plugin/HClust.js
+++ b/web-app/js/plugin/HClust.js
@@ -51,6 +51,7 @@ HierarchicalClusteringView.prototype.get_form_params = function () {
         var maxDrawNum = inputArray[1].el.value;
         var doClusterRows = inputArray[2].el.checked;
         var doClusterColumns = inputArray[3].el.checked;
+        var calculateZscore = inputArray[4].el.checked;
 
         // assign values to form parameters
         formParameters['jobType'] = 'RHClust';
@@ -59,11 +60,15 @@ HierarchicalClusteringView.prototype.get_form_params = function () {
         formParameters['txtMaxDrawNumber'] = maxDrawNum;
         formParameters['doClusterRows'] = doClusterRows;
         formParameters['doClusterColumns'] = doClusterColumns;
+        formParameters['calculateZscore'] = calculateZscore;
 
         //get analysis constraints
         var constraints_json = this.get_analysis_constraints('RHClust');
-        constraints_json['projections'] = ["zscore"];
-
+        if(calculateZscore){
+        	constraints_json['projections'] = ["log_intensity"];
+        }else{
+        	constraints_json['projections'] = ["zscore"];
+        }
         formParameters['analysisConstraints'] = JSON.stringify(constraints_json);
 
     } else { // something is not correct in the validation
@@ -103,6 +108,11 @@ HierarchicalClusteringView.prototype.get_inputs = function (form_params) {
         {
             "label" : "Do cluster columns",
             "el" : document.getElementById("chkClusterColumns"),
+            "validations" : []
+        },
+        {
+            "label" : "Calculate z-score on the fly",
+            "el" : document.getElementById("chkCalculateZscore"),
             "validations" : []
         }
     ];

--- a/web-app/js/plugin/Heatmap.js
+++ b/web-app/js/plugin/Heatmap.js
@@ -67,6 +67,7 @@ HeatMapView.prototype.get_form_params = function () {
         var inputConceptPathVar = readConceptVariables("divIndependentVariable");
         var maxDrawNum = inputArray[1].el.value;
         var doGroupBySubject = inputArray[2].el.checked;
+        var calculateZscore = inputArray[3].el.checked;
 
         // assign values to form parameters
         formParameters['jobType'] = 'RHeatmap';
@@ -74,10 +75,15 @@ HeatMapView.prototype.get_form_params = function () {
         formParameters['variablesConceptPaths'] = inputConceptPathVar;
         formParameters['txtMaxDrawNumber'] = maxDrawNum;
         formParameters['doGroupBySubject'] = doGroupBySubject;
+        formParameters['calculateZscore'] = calculateZscore;
 
         // get analysis constraints
         var constraints_json = this.get_analysis_constraints('RHeatmap');
-        constraints_json['projections'] = ["zscore"];
+        if(calculateZscore){
+        	constraints_json['projections'] = ["log_intensity"];
+        }else{
+        	constraints_json['projections'] = ["zscore"];
+        }
 
         formParameters['analysisConstraints'] = JSON.stringify(constraints_json);
 
@@ -113,6 +119,11 @@ HeatMapView.prototype.get_inputs = function (form_params) {
         {
             "label" : "Do Group by Subject",
             "el" : document.getElementById("chkGroupBySubject"),
+            "validations" : []
+        },
+        {
+            "label" : "Calculate z-score on the fly",
+            "el" : document.getElementById("chkCalculateZscore"),
             "validations" : []
         }
     ];

--- a/web-app/js/plugin/KClust.js
+++ b/web-app/js/plugin/KClust.js
@@ -49,6 +49,7 @@ KMeansClusteringView.prototype.get_form_params = function () {
         var inputConceptPathVar = readConceptVariables("divIndependentVariable");
         var clusters = inputArray[1].el.value;
         var maxDrawNum = inputArray[2].el.value;
+        var calculateZscore = inputArray[3].el.checked;
 
         // assign values to form parameters
         formParameters['jobType'] = 'RKClust';
@@ -56,10 +57,15 @@ KMeansClusteringView.prototype.get_form_params = function () {
         formParameters['variablesConceptPaths'] = inputConceptPathVar;
         formParameters['txtClusters'] = clusters;
         formParameters['txtMaxDrawNumber'] = maxDrawNum;
+        formParameters['calculateZscore'] = calculateZscore;
 
         //get analysis constraints
         var constraints_json = this.get_analysis_constraints('RKClust');
-        constraints_json['projections'] = ["zscore"];
+        if(calculateZscore){
+        	constraints_json['projections'] = ["log_intensity"];
+        }else{
+        	constraints_json['projections'] = ["zscore"];
+        }
 
         formParameters['analysisConstraints'] = JSON.stringify(constraints_json);
 
@@ -96,6 +102,11 @@ KMeansClusteringView.prototype.get_inputs = function (form_params) {
             "label" : "Max Row to Display",
             "el" : document.getElementById("txtMaxDrawNumber"),
             "validations" : [{type:"INTEGER", min:1}]
+        },
+        {
+            "label" : "Calculate z-score on the fly",
+            "el" : document.getElementById("chkCalculateZscore"),
+            "validations" : []
         }
     ];
 }

--- a/web-app/js/plugin/MarkerSelection.js
+++ b/web-app/js/plugin/MarkerSelection.js
@@ -67,6 +67,7 @@ MarkerSelectionView.prototype.get_form_params = function () {
         var inputConceptPathVar = readConceptVariables("divIndependentVariable");
         var numOfMarkers = inputArray[1].el.value;
         var doGroupBySubject = inputArray[3].el.checked;
+        var calculateZscore = inputArray[4].el.checked;
 
         // assign values to form parameters
         formParameters['jobType'] = 'MarkerSelection';
@@ -74,11 +75,16 @@ MarkerSelectionView.prototype.get_form_params = function () {
         formParameters['variablesConceptPaths'] = inputConceptPathVar;
         formParameters['txtNumberOfMarkers'] = numOfMarkers;
         formParameters['doGroupBySubject'] = doGroupBySubject;
+        formParameters['calculateZscore'] = calculateZscore;
 
         // get analysis constraints
         var constraints_json = this.get_analysis_constraints('MarkerSelection');
-        constraints_json['projections'] = ["log_intensity"];
-
+        if(calculateZscore){
+        	constraints_json['projections'] = ["log_intensity"];
+        }else{
+        	constraints_json['projections'] = ["zscore"];
+        }
+        
         formParameters['analysisConstraints'] = JSON.stringify(constraints_json);
 
     } else { // something is not correct in the validation
@@ -119,6 +125,11 @@ MarkerSelectionView.prototype.get_inputs = function (form_params) {
         {
             "label" : "Do Group by Subject",
             "el" : document.getElementById("chkGroupBySubject"),
+            "validations" : []
+        },
+        {
+            "label" : "Calculate z-score on the fly",
+            "el" : document.getElementById("chkCalculateZscore"),
             "validations" : []
         }
     ];

--- a/web-app/js/plugin/PCA.js
+++ b/web-app/js/plugin/PCA.js
@@ -48,16 +48,22 @@ PCAView.prototype.get_form_params = function () {
         // get values
         var inputConceptPathVar = readConceptVariables("divIndependentVariable");
         var doUseExperimentAsVariable = inputArray[1].el.checked;
+        var calculateZscore = inputArray[2].el.checked;
 
         // assign values to form parameters
         formParameters['jobType'] = 'PCA';
         formParameters['independentVariable'] = inputConceptPathVar;
         formParameters['variablesConceptPaths'] = inputConceptPathVar;
         formParameters['doUseExperimentAsVariable'] = doUseExperimentAsVariable;
+        formParameters['calculateZscore'] = calculateZscore;
 
         //get analysis constraints
         var constraints_json = this.get_analysis_constraints('PCA');
-        constraints_json['projections'] = ["zscore"];
+        if(calculateZscore){
+        	constraints_json['projections'] = ["log_intensity"];
+        }else{
+        	constraints_json['projections'] = ["zscore"];
+        }
 
         formParameters['analysisConstraints'] = JSON.stringify(constraints_json);
 
@@ -88,6 +94,11 @@ PCAView.prototype.get_inputs = function (form_params) {
         {
             "label" : "Do Use Experiment As Variable",
             "el" : document.getElementById("chkUseExperimentAsVariable"),
+            "validations" : []
+        },
+        {
+            "label" : "Calculate z-score on the fly",
+            "el" : document.getElementById("chkCalculateZscore"),
             "validations" : []
         }
     ];


### PR DESCRIPTION
The principle of the enhancement is to be able to choose a z-score on the fly calculation (z-score calculated for the cohort selected) and supersede the z-score calculation done at the data loading step (z-score calculated based on the whole cohort loaded).
This option appears in the advanced workflow and is available for the following analyses: Heatmap, K-Means Clustering, Hierarchical Clustering, Marker Selection and PCA.