### PR TITLE
Prune concept to shortest unique leaf.

### DIFF
--- a/grails-app/utils/org/transmartproject/utils/ConceptUtils.groovy
+++ b/grails-app/utils/org/transmartproject/utils/ConceptUtils.groovy
@@ -1,0 +1,45 @@
+package org.transmartproject.utils
+
+import java.util.regex.Pattern
+
+class ConceptUtils {
+
+    static final String SEP = '\\'
+
+    private static shortenToUniqueTails(List<List<String>> partsList, int step = 0) {
+        int revPos = -(step + 1)
+        Map<String, List<List<String>>> groups = partsList.groupBy { List<String> parts ->
+            if (parts.size() > step) {
+                parts[revPos]
+            }
+        }
+        groups.each {
+            //Concepts that grouped under it.key == null do not have so many levels.
+            if (it.key && it.value.size() > 1) {
+                shortenToUniqueTails(it.value, step + 1)
+            } else if (it.key) {
+                def parts = it.value[0]
+                //remove all parts of the concept path from the root down to current element (excluding it).
+                //note that we are changing input list here
+                (parts.size() + revPos).times { parts.remove(0) }
+            }
+        }
+    }
+
+    /**
+     * Shorten the paths to shortest ones, but still unique in current scope
+     * (among concepts represented in the input list) by removing higher levels
+     * that are not important for uniqueness of this concept in given scope.
+     * Although it does not guarantee uniqueness if input list already contains repetitions.
+     * e.g. Given input list ['\A\B\C\', '\A\2\C\', '\B\C\', '\B\C\']
+     * function returns ['\A\B\C\', '\2\C\', '\B\C\', '\B\C\']
+     * @param conceptPathes concepts to shorten
+     * @return shortened and normalized concept paths
+     */
+    static List<String> shortestUniqueTails(List<String> conceptPathes) {
+        List<List<String>> conceptsParts = conceptPathes.collect { it.split(Pattern.quote(SEP)).findAll() }
+        shortenToUniqueTails(conceptsParts)
+        conceptsParts.collect { SEP + it.join(SEP) + SEP }
+    }
+
+}

--- a/src/groovy/jobs/LineGraph.groovy
+++ b/src/groovy/jobs/LineGraph.groovy
@@ -55,7 +55,6 @@ class LineGraph extends AbstractAnalysisJob {
         measurementConfigurator.multiRow              = true
         measurementConfigurator.multiConcepts         = true
         // we do not want group name pruning for LineGraph
-        measurementConfigurator.pruneConceptPath      = false
 
         measurementConfigurator.keyForConceptPath     = 'dependentVariable'
         measurementConfigurator.keyForDataType        = 'divDependentVariableType'

--- a/src/groovy/jobs/steps/helpers/ContextNumericVariableColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/ContextNumericVariableColumnConfigurator.groovy
@@ -41,7 +41,6 @@ class ContextNumericVariableColumnConfigurator extends ColumnConfigurator {
      * - keyForSearchKeywordId
      * - multiRow
      * - multiConcepts
-     * - pruneConceptPath
      */
 
     @Autowired

--- a/src/groovy/jobs/steps/helpers/HighDimensionColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/HighDimensionColumnConfigurator.groovy
@@ -40,9 +40,6 @@ class HighDimensionColumnConfigurator extends ColumnConfigurator {
     // multiConcepts => multiRow
     boolean multiConcepts = false
 
-    // not implemented
-    //boolean pruneConceptPath = false
-
     boolean isMultiConcepts() {
         multiConcepts
     }

--- a/src/groovy/jobs/steps/helpers/MultiNumericClinicalVariableColumnConfigurator.groovy
+++ b/src/groovy/jobs/steps/helpers/MultiNumericClinicalVariableColumnConfigurator.groovy
@@ -6,16 +6,14 @@ import jobs.table.columns.MultiNumericClinicalVariableColumn
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Scope
 import org.springframework.stereotype.Component
-import org.transmartproject.core.dataquery.clinical.ClinicalVariable
 import org.transmartproject.core.dataquery.clinical.ClinicalVariableColumn
+import org.transmartproject.utils.ConceptUtils
 
 @Component
 @Scope('prototype')
 class MultiNumericClinicalVariableColumnConfigurator extends ColumnConfigurator {
 
     String keyForConceptPaths
-
-    boolean pruneConceptPath = true
 
     GroupNamesHolder groupNamesHolder
 
@@ -28,7 +26,7 @@ class MultiNumericClinicalVariableColumnConfigurator extends ColumnConfigurator 
     @Override
     protected void doAddColumn(Closure<Column> decorateColumn) {
 
-        List<ClinicalVariable> variables = getConceptPaths().collect {
+        List<String> variables = getConceptPaths().collect {
             clinicalDataRetriever.createVariableFromConceptPath it
         }
 
@@ -40,7 +38,7 @@ class MultiNumericClinicalVariableColumnConfigurator extends ColumnConfigurator 
 
         Map<ClinicalVariableColumn, String> variableToGroupName =
                 Functions.inner(variables,
-                        conceptPaths.collect { generateGroupName it },
+                        ConceptUtils.shortestUniqueTails(conceptPaths),
                         { a, b -> [a,b]}).
                         collectEntries()
 
@@ -60,12 +58,4 @@ class MultiNumericClinicalVariableColumnConfigurator extends ColumnConfigurator 
         getStringParam(keyForConceptPaths).split(/\|/) as List
     }
 
-    private String generateGroupName(String conceptPath) {
-        if (pruneConceptPath)  {
-            /* find last non-empty segment (separated by \) */
-            conceptPath.split('\\\\').findAll()[-1]
-        } else {
-            conceptPath
-        }
-    }
 }

--- a/test/integration/jobs/steps/helpers/BoxPlotVariableColumnConfiguratorTests.groovy
+++ b/test/integration/jobs/steps/helpers/BoxPlotVariableColumnConfiguratorTests.groovy
@@ -94,13 +94,13 @@ class BoxPlotVariableColumnConfiguratorTests {
             def res = table.result
             assertThat res, containsInAnyOrder(
                     contains(allOf(
-                            dot(['var 1', 'var 2', 'var 3'],
+                            dot(['\\var 1\\', '\\var 2\\', '\\var 3\\'],
                                     valuesForColumns[0..2], { a, b ->
                                 hasEntry(is(a), is(b))
                             }
                             ))),
                     contains(allOf(
-                            dot(['var 1', 'var 2', 'var 3'],
+                            dot(['\\var 1\\', '\\var 2\\', '\\var 3\\'],
                                     valuesForColumns[3..5], { a, b ->
                                         hasEntry(is(a), is(b))
                                     }

--- a/test/integration/jobs/steps/helpers/ContextNumericVariableColumnConfiguratorTests.groovy
+++ b/test/integration/jobs/steps/helpers/ContextNumericVariableColumnConfiguratorTests.groovy
@@ -48,7 +48,6 @@ class ContextNumericVariableColumnConfiguratorTests {
         testee.keyForDataType        = 'dataType'
         testee.keyForSearchKeywordId = 'searchKeywordId'
         testee.multiConcepts         = true
-        testee.pruneConceptPath      = false
     }
 
     @Test
@@ -135,7 +134,7 @@ class ContextNumericVariableColumnConfiguratorTests {
             // no maps involved here
             assertThat Lists.newArrayList(table.result), contains(
                     contains(allOf(
-                            dot(BUNDLE_OF_CLINICAL_CONCEPT_PATH, data) { a, b -> hasEntry(a, b) })))
+                            dot(['\\var 1\\', '\\var 2\\', '\\var 3\\'], data) { a, b -> hasEntry(a, b) })))
         }
     }
 
@@ -191,7 +190,7 @@ class ContextNumericVariableColumnConfiguratorTests {
 
             // no maps involved here
             assertThat Lists.newArrayList(table.result), contains(
-                    contains([(CONCEPT_PATH_CLINICAL): 34.0]))
+                    contains([('\\variable\\'): 34.0]))
         }
     }
 }

--- a/test/unit/org/transmartproject/utils/ConceptUtilsTests.groovy
+++ b/test/unit/org/transmartproject/utils/ConceptUtilsTests.groovy
@@ -1,0 +1,92 @@
+package org.transmartproject.utils
+
+import grails.test.mixin.TestMixin
+import grails.test.mixin.support.GrailsUnitTestMixin
+import org.junit.Test
+
+import static ConceptUtils.shortestUniqueTails
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.equalTo
+
+@TestMixin(GrailsUnitTestMixin)
+class ConceptUtilsTests {
+
+    @Test
+    void testShortestUniqueTailsForEmpty() {
+        List<String> actualResult = ConceptUtils.shortestUniqueTails([])
+
+        assertThat actualResult, equalTo([])
+    }
+
+    @Test
+    void testShortestUniqueTailsNormalization() {
+        List<String> actualResult = shortestUniqueTails([
+                'C',
+        ])
+
+        assertThat actualResult, equalTo([
+                '\\C\\',
+        ])
+    }
+
+    @Test
+    void testShortestUniqueTailsForSingleConcept() {
+        List<String> actualResult = shortestUniqueTails([
+                '\\A\\B\\C\\',
+        ])
+
+        assertThat actualResult, equalTo([
+                '\\C\\',
+        ])
+    }
+
+    @Test
+    void testShortestUniqueTailsForDuplicates() {
+        List<String> actualResult = shortestUniqueTails([
+                '\\A\\B\\C\\',
+                '\\A\\B\\C\\',
+        ])
+
+        assertThat actualResult, equalTo([
+                '\\A\\B\\C\\',
+                '\\A\\B\\C\\',
+        ])
+    }
+
+    @Test
+    void testShortestUniqueTailsSameLevel() {
+        List<String> actualResult = shortestUniqueTails([
+                '\\1\\2\\3\\4\\',
+                '\\1\\2\\3\\A\\',
+                '\\1\\2\\B\\A\\',
+                '\\1\\C\\B\\A\\',
+                '\\D\\C\\B\\A\\',
+        ])
+
+        assertThat actualResult, equalTo([
+                '\\4\\',
+                '\\3\\A\\',
+                '\\2\\B\\A\\',
+                '\\1\\C\\B\\A\\',
+                '\\D\\C\\B\\A\\',
+        ])
+    }
+
+    @Test
+    void testShortestUniqueTailsDiffLevels() {
+        List<String> actualResult = shortestUniqueTails([
+                '\\A\\',
+                '\\B\\A\\',
+                '\\C\\B\\A\\',
+                '\\D\\C\\B\\A\\',
+        ])
+
+        assertThat actualResult, equalTo([
+                '\\A\\',
+                '\\B\\A\\',
+                '\\C\\B\\A\\',
+                '\\D\\C\\B\\A\\',
+        ])
+    }
+
+}

--- a/test/unit/org/transmartproject/utils/FileUtilsTest.groovy
+++ b/test/unit/org/transmartproject/utils/FileUtilsTest.groovy
@@ -1,4 +1,4 @@
-package com.transmart.utils
+package org.transmartproject.utils
 
 import grails.test.GrailsUnitTestCase
 import org.transmartproject.utils.FileUtils


### PR DESCRIPTION
Fix for bug: FT-1269 Correlation Analysis fails for
different concept(path)s which have the same name as leaf node