### PR TITLE
Empty result table issue

### DIFF
--- a/web-app/js/plugin/GroupTestRNASeq.js
+++ b/web-app/js/plugin/GroupTestRNASeq.js
@@ -427,7 +427,7 @@ var RNASeqGroupTestView = Ext.extend(GenericAnalysisView, {
                     // load using script tags for cross domain, if the data in on the same domain as
                     // this page, an HttpProxy would be better
                     proxy: new Ext.data.HttpProxy({
-                        url: "../RNASeqgroupTest/resultTable"
+                        url: pageInfo.basePath + "/RNASeqgroupTest/resultTable"
                     })
 
                 });

--- a/web-app/js/plugin/GroupTestaCGH.js
+++ b/web-app/js/plugin/GroupTestaCGH.js
@@ -490,7 +490,7 @@ var GroupTestView = Ext.extend(GenericAnalysisView, {
                     // load using script tags for cross domain, if the data in on the same domain as
                     // this page, an HttpProxy would be better
                     proxy: new Ext.data.HttpProxy({
-                        url: "../aCGHgroupTest/resultTable"
+                        url: pageInfo.basePath + "/aCGHgroupTest/resultTable"
                     })
 
                 });


### PR DESCRIPTION
Use absolute reference to result table controller.
Before this fix relative reference did work when
current url path used to be `/transmart/datasetExplorer/index`
but did not work for `/transmart/datasetExplorer/`