### PR TITLE
Wrong order of gene symbols for top genes in MS (leading to not matching MRNA data with top genes)

### DIFF
--- a/web-app/Rscripts/MarkerSelection/MarkerSelection.R
+++ b/web-app/Rscripts/MarkerSelection/MarkerSelection.R
@@ -161,7 +161,7 @@ zscore.file = "zscores.txt"
 	rownames(top.fit.ranked.decr) = NULL
 	
 	top.fit.ranked.decr.filt = top.fit.ranked.decr[1:numberOfMarkers,]
-	topgenes = cbind(gene.symbols[top.fit.ranked.decr.filt$ID], top.fit.ranked.decr.filt)
+	topgenes = cbind(gene.symbols[as.vector(top.fit.ranked.decr.filt$ID)], top.fit.ranked.decr.filt)
 	colnames(topgenes) = c("GENE_SYMBOL", "PROBE.ID", "logFC", "t", "P.value", "adj.P.val", "B")
 	rownames(topgenes) = NULL
 	


### PR DESCRIPTION
In some cases following statement build invalid `topgenes` data frame:

```Groovy
topgenes = cbind(gene.symbols[top.fit.ranked.decr.filt$ID], top.fit.ranked.decr.filt)
```

It happens because `gene.symbols[top.fit.ranked.decr.filt$ID]` returns gene symbols vector in different order than top.fit.ranked.decr.filt rows. So it creates wrong probe.id, gene_symbol pairs, which can't be matched to MRNA data.