### PR TITLE
logistic regression bug fixes and improvements

### DIFF
--- a/grails-app/views/plugin/LogisticRegression.gsp
+++ b/grails-app/views/plugin/LogisticRegression.gsp
@@ -18,17 +18,23 @@
             %{-- ************************************************************************************************* --}%
             <div class="left">
                 <fieldset class="inputFields">
-                    <h3>Independent Variable</h3>
-                    <span class="hd-notes">
-                        Drag a <b>numerical</b> concept from the tree into the box below. The concept must come from a
-                        data node (Biomarker Data or Clinical Data).  <br><br><br><br><br><br><br>
-                    </span>
-                    <div id='divIndependentVariable' class="queryGroupIncludeSmall highDimBox"></div>
-                    <div class="highDimBtns">
-                        <button type="button" onclick="logisticRegressionView.clear_high_dimensional_input('divIndependentVariable')">Clear</button>
+                    <div class="highDimContainer">
+                        <h3>Independent Variable</h3>
+                        <span class="hd-notes">
+                            Drag a <b>numerical</b> or <b>high dimensional</b> concept from the Data Set Explorer Tree into the box below.
+                            <br><br><br><br><br><br><br><br>
+                        </span>
+                        <div id='divIndependentVariable' class="queryGroupIncludeSmall highDimBox"></div>
+                        <div class="highDimBtns">
+                            <button type="button" onclick="highDimensionalData.gather_high_dimensional_data('divIndependentVariable', true)">High Dimensional Data</button>
+                            <button type="button" onclick="logisticRegressionView.clear_high_dimensional_input('divIndependentVariable')">Clear</button>
+                        </div>
+                        <input type="hidden" id="independentVarDataType">
+                        <input type="hidden" id="independentPathway">
                     </div>
 
-
+                    %{--Display independent variable--}%
+                    <div id="displaydivIndependentVariable" class="independentVariable"></div>
                 </fieldset>
             </div>
 
@@ -38,20 +44,28 @@
 
             <div class="right">
                 <fieldset class="inputFields">
-                    <h3>Outcome</h3>
-                    <span class="hd-notes">
-                        For the binary response, among two possible outcomes (Commonly the generic terms success and
-                        failure are used for these two outcomes). Drag the two related <b>categorical concepts</b>
-                        from the tree into the box below (for example, Subjects with Malignant Vs. Subjects with
-                        Benign Tumors). A folder may be dragged in to include the two leaf nodes under that folder.
-                        <br> <i>NOTE: The top concept will always be designated a value of 1 and the other a
-                        value of 0.</i>
-                    </span>
-                    <div id='divGroupByVariable' class="queryGroupIncludeSmall highDimBox"></div>
-                    <div class="highDimBtns">
-                        <button type="button" onclick="logisticRegressionView.clear_high_dimensional_input('divGroupByVariable')">Clear</button>
+                    <div class="highDimContainer">
+                        <h3>Outcome</h3>
+                        <span class="hd-notes">
+                            For the binary response, among two possible outcomes (Commonly the generic terms success and
+                            failure are used for these two outcomes). Drag the two related <b>categorical concepts</b>
+                            from the tree into the box below (for example, Subjects with Malignant Vs. Subjects with
+                            Benign Tumors). A folder may be dragged in to include the two leaf nodes under that folder.
+                            Or a continuous of high dimensional variable may be selected and categorized using the binning option below.
+                            <br> <i>NOTE: The top concept or the first bin will always be designated a value of 1 (success) and
+                            the other a value of 0 (failure).</i>
+                        </span>
+                        <div id='divGroupByVariable' class="queryGroupIncludeSmall highDimBox"></div>
+                        <div class="highDimBtns">
+                            <button type="button" onclick="highDimensionalData.gather_high_dimensional_data('divGroupByVariable', true)">High Dimensional Data</button>
+                            <button type="button" onclick="logisticRegressionView.clear_high_dimensional_input('divGroupByVariable')">Clear</button>
+                        </div>
+                        <input type="hidden" id="groupByVarDataType">
+                        <input type="hidden" id="groupByPathway">
                     </div>
 
+                    %{--Display group variable--}%
+                    <div id="displaydivGroupByVariable" class="groupByVariable"></div>
                     %{--Binning options--}%
                     <fieldset class="binningDiv">
 

--- a/web-app/Rscripts/LogisticRegression/LogisticRegressionLoader.R
+++ b/web-app/Rscripts/LogisticRegression/LogisticRegressionLoader.R
@@ -22,28 +22,50 @@ LogisticRegressionData.loader <- function(
 	library(ggplot2)
 	library(Cairo)
 	library(visreg)
+	pROC.available <- "pROC" %in% row.names(installed.packages())
+	if (pROC.available) library(pROC)
 	######################################################
 	
 	######################################################
 	#Read the line graph data.
 	line.data<-read.delim(input.filename,header=T)
 	
-	if(length(levels(line.data$X)) < 2)
+	nDataConcepts <- length(levels(line.data$X))
+	if(nDataConcepts != 2)
 	{
-		stop("||FRIENDLY||After extracting data only one categorical concept was found. Please verify your variable selection and try again.")
+		stop(paste("||FRIENDLY||After extracting data ",nDataConcepts," categorical concepts were found while 2 concepts are expected. Please verify your variable selection and try again."))
 	}
 	
-  #yaxislabels
- 	yLabel <- unique(line.data$X)
+	# If (two) categorical concepts are used to define both outcome groups (no binning of numerical or categorical variables),
+	# the order of those categorical concepts as specified by the user, determines the mapping to EventOccurred (numeric value 1).
+	# If some form of binning is used to define both outcome groups (e.g. "bin1" and "bin2"), the alphabetical order will be used to define the mapping.
+ 	conceptsData <- sort(unique(line.data$X))
+
+	# Split the concept.dependent argument into seperate concept paths
+	conceptpathsDependent <- unlist(strsplit(concept.dependent,"\\|"));
+	if (length(conceptpathsDependent) == 2)
+	{   # Check if the conceptPaths should determine order for mapping
+		# Extract labels from conceptpaths
+		conceptLabelsDependent <- unlist(lapply(conceptpathsDependent,extractLabelFromConceptPath))
+
+		# Check if conceptLabels equal data found in line.data$X
+		if ( all(sort(conceptLabelsDependent)==conceptsData)) {
+		# The order of the dependent concept paths determines which concept needs to be mapped to EventOccured (numeric value 1)
+ 			conceptsData <- conceptLabelsDependent
+		}
+	}
+
+	yLabel <- conceptsData
+	# The first concept is mapped to EventOccurred (numeric value 1), the second is mapped to 0
  	yAxisLabel1 <- paste(yLabel[1],sep="")
  	yAxisLabel0 <- paste(yLabel[2],sep="")
    
-	#We need to convert the value column from a factor to a numeric 0 or 1 values
-	line.data$X <- factor(line.data$X,labels = c(0,1))
-	
+	# We need to convert the value column from a factor to a numeric 0 or 1 values
+	# The first concept is mapped to EventOccurred (numeric value 1)
+	line.data <- transform(line.data, X = ifelse(X==yAxisLabel1,1,0))
 	
 	# fit a binomial generalized linear models (glm)
-	 logReg.fit <- glm(X~Y,data=line.data,family="binomial")
+	logReg.fit <- glm(X~Y,data=line.data,family="binomial")
 	
 	#The filename for the summary stats file.
 	coefFileName <- paste("LOGREG_RESULTS",".txt",sep="")
@@ -54,22 +76,20 @@ LogisticRegressionData.loader <- function(
 	
 	# To test the overall fit of the model by once again treating it as a chi square value. 
 	# A chi square of residual  deviance  on number of  degrees of freedom yields the overall model fit p-value . 
-	 overall.model.pvalue<-1-pchisq(summaryLogReg$deviance,summaryLogReg$df[2])
-	
+	overall.model.pvalue<-1-pchisq(summaryLogReg$deviance,summaryLogReg$df[2])
 	
 	write("||PVALUES||", file=coefFileName,append=T)
-	
 		
 	#Write the coefficient values to a file.
  	write(paste("I.p=",format(summaryLogReg$coef['(Intercept)', "Pr(>|z|)"],digits=3),sep=""), file=coefFileName,append=TRUE)
- 	write(paste("I.est=",format(summaryLogReg$coef['(Intercept)', "Estimate"],digits=3),sep=""), file=coefFileName,append=TRUE)	 	
+ 	write(paste("I.est=",format(summaryLogReg$coef['(Intercept)', "Estimate"],digits=3),sep=""), file=coefFileName,append=TRUE)
  	write(paste("I.zvalue=",format(summaryLogReg$coef['(Intercept)', "z value"],digits=3),sep=""), file=coefFileName,append=TRUE)
  	write(paste("I.std=",format(summaryLogReg$coef['(Intercept)', "Std. Error"],digits=3),sep=""), file=coefFileName,append=TRUE)  
 		
  	
  	write(paste("Y.p=",format(summaryLogReg$coef['Y', "Pr(>|z|)"],digits=3),sep=""), file=coefFileName,append=TRUE)
  	write(paste("Y.est=",format(summaryLogReg$coef['Y', "Estimate"],digits=3),sep=""), file=coefFileName,append=TRUE)
- 	write(paste("Y.zvalue=",format(summaryLogReg$coef['Y', "z value"],digits=3),sep=""), file=coefFileName,append=TRUE)	 	
+ 	write(paste("Y.zvalue=",format(summaryLogReg$coef['Y', "z value"],digits=3),sep=""), file=coefFileName,append=TRUE)
  	write(paste("Y.std=",format(summaryLogReg$coef['Y', "Std. Error"],digits=3),sep=""), file=coefFileName,append=TRUE)	
 	
 
@@ -80,7 +100,7 @@ LogisticRegressionData.loader <- function(
  	
  	#Write the Deviance Residuals values to a file.
  	write(paste("deviance.resid.min=",format(min(summaryLogReg$deviance.resid),digits=3),sep=""), file=coefFileName,append=TRUE)
- 	write(paste("deviance.resid.1Q=",format(quantile(summaryLogReg$deviance.resid,0.25),digits=3),sep=""), file=coefFileName,append=TRUE)	 	
+ 	write(paste("deviance.resid.1Q=",format(quantile(summaryLogReg$deviance.resid,0.25),digits=3),sep=""), file=coefFileName,append=TRUE)
  	write(paste("deviance.resid.med=", format(median(summaryLogReg$deviance.resid),digits=3),sep=""), file=coefFileName,append=TRUE)
  	write(paste("deviance.resid.3Q=",format(quantile(summaryLogReg$deviance.resid,0.75),digits=3),sep=""), file=coefFileName,append=TRUE)  
  	write(paste("deviance.resid.max=", format(max(summaryLogReg$deviance.resid),digits=3),sep=""), file=coefFileName,append=TRUE)  
@@ -89,8 +109,6 @@ LogisticRegressionData.loader <- function(
 	write(paste("overall.model.pvalue=", format(overall.model.pvalue,digits=3),sep=""), file=coefFileName,append=TRUE)   	
  	
 	#write the Dev 
- 
-
 
 	print(summaryLogReg)
 	
@@ -104,41 +122,30 @@ LogisticRegressionData.loader <- function(
 
 	######################################################
 	#Label the Axis.		
-	
-	xAxisLabel <- "";
+	xAxisLabel <- extractLabelFromConceptPath(concept.independent)
 
-   
-	
-			xAxisLabel <- sub(pattern="^\\\\(.*?\\\\){3}",replacement="",x=concept.dependent,perl=TRUE)	
-			splitConcept <- strsplit(concept.independent,"\\|");
-			splitConcept <- unlist(splitConcept);
-			#yLabel <- sub(pattern="^\\\\(.*?\\\\){5}",replacement="",x=splitConcept,perl=TRUE)
- 	    #yLabel <- unique(line.data$X)
-	        #tempYAxisLabel <- paste(rev(yLabel), collapse= "-")
-	        #yAxisLabel1 <- yLabel[1]
- 	        #yAxisLabel0 <- yLabel[2]
- 	
 	######################################################
-	#Plotting the line.
+	#Prepare image.
 
-
-	
 	#This is the name of the output image file.
 	imageFileName <- paste(output.file,".png",sep="")
 	
 	#This initializes our image capture object.
-	CairoPNG(file=imageFileName, width=700, height=700,units = "px")	
+	if (pROC.available) {
+		CairoPNG(file=imageFileName, width=1000, height=1000, units="px")
+		#par(mfrow = c(2,1), cex=1.3)
+		layout(matrix(c(0,1,0,2),2,2,byrow=TRUE), heights=c(1,1), widths=c(1,5))
+		par(cex=1.3, lwd=2, cex.axis=1.5, cex.lab=1.5, cex.main=1.5, cex.sub=1.5, mar=c(5,4,4,2)+.1)
+	} else {
+		CairoPNG(file=imageFileName, width=700, height=700, units="px")
+	}
+
+	######################################################
+	#Plotting the line.
 	
-	#yAxisLabel <- paste("P (",yAxisLabel,")",sep=" ")
+	#yAxisLabel0 <- paste("P(",yAxisLabel0,")",sep=" ")
+	#yAxisLabel1 <- paste("P(",yAxisLabel1,")",sep=" ")
 	
-	
-	#Printing actually puts the plot in the image.
-	# visreg(logReg.fit,scale="response", xlab=xAxisLabel,ylab=yAxisLabel)
-	
-   
-   
-   
-   
  	#Printing actually puts the plot in the image.
  	visreg(logReg.fit,scale="response", partial=FALSE, xlab="",ylab="",yaxt="n")
  	
@@ -146,38 +153,61 @@ LogisticRegressionData.loader <- function(
  	par(new=T)   
  	X <- as.numeric(paste(line.data$X)) 
    
- 	#plot observed events/non-events (dots across the top or bottom).
- 	plot(X~line.data$Y,type="p",axes=F, pch=20,cex = .9,  yaxt="n", xlab=xAxisLabel,ylab="P(Outcome)")
- 	axis(2, at=c(0, .2,.4,.6,.8,1),labels=c(yAxisLabel0,".2",".4",".6",".8",yAxisLabel1),las=0)
+	#plot observed events/non-events (dots across the top or bottom).
+	plot(X~line.data$Y,type="p",axes=F, pch=20,cex = .9,  yaxt="n", xlab=xAxisLabel,ylab="P(Outcome)")
+	axis(2, at=c(0, .2,.4,.6,.8,1),labels=c(yAxisLabel0,".2",".4",".6",".8",yAxisLabel1),las=2)
 
-   
+	if (pROC.available) {
+		# Create ROC curve
+		roc.curve <- roc(X~Y,data=line.data)
+		par(pty="s", asp=1)
+		plot.roc(roc.curve, percent=FALSE, auc.polygon=TRUE, max.auc.polygon=TRUE, grid=TRUE, print.auc=TRUE, show.thres=TRUE, print.auc.cex=1.5)
+
+		# Alternative ROC curve creation which for the univariate case is identical to the direct method above
+		# Create ROC curve from probabilities extracted from regression model
+		#predicted.prob <- predict(logReg.fit, type=c("response"))
+		#roc.curve.prob <- roc(line.data$X,predicted.prob)
+		#plot(roc.curve.prob, percent=FALSE, auc.polygon=TRUE, max.auc.polygon=TRUE, grid=TRUE, print.auc=TRUE, show.thres=TRUE)
+	}
+
 	#Turn of the graphics device to save the image.
 	dev.off()
 	######################################################
 }
+
 createAxisLabel <- function(concept.type,concept,genes)
 {
 	axisLabel <- ""
 
-	if(concept.type == "CLINICAL") axisLabel <- sub(pattern="^\\\\(.*?\\\\){3}",replacement="",x=concept,perl=TRUE)
+	if(concept.type == "CLINICAL") axisLabel <- extractLabelFromConceptPath(concept)
 	#if(concept.type == "MRNA") axisLabel <- paste(genes,"Gene Expression (zscore)",sep=" ")
 	#if(concept.type == "SNP") axisLabel <- "SNP"
 
 	return(axisLabel)
 }
+
+extractLabelFromConceptPath <- function(concept.path)
+{   # Retrieve last part of concept path
+	# Assume format of path string is "\\" { <subpath> "\\" }+
+	# Remove double backslash at the end
+	strippedPath <- sub(pattern="\\\\$",replacement="",x=concept.path)
+	label <- sub(pattern="^\\\\(.*\\\\)+",replacement="",x=strippedPath)
+	return(label)
+}
+
 createSummaryCoef<-function(a){
-     coef(summary(a))->lo
-     a<-colnames(lo)
-     b<-rownames(lo)
-     c<-length(a)
-     e<-character(0)
-     r<-NULL
-     for (x in (1:c)){
-         d<-rep(paste(a[1:c],b[x],sep=" "))
-         e<-paste(c(e,d))
-         t<-lo[x,]
-         r<-c(r,t)
-         names(r)<-e
-     }
-     return(r)
+	coef(summary(a))->lo
+	a<-colnames(lo)
+	b<-rownames(lo)
+	c<-length(a)
+	e<-character(0)
+	r<-NULL
+	for (x in (1:c)){
+		d<-rep(paste(a[1:c],b[x],sep=" "))
+		e<-paste(c(e,d))
+		t<-lo[x,]
+		r<-c(r,t)
+		names(r)<-e
+	}
+	return(r)
  }


### PR DESCRIPTION
@forus 
The modifications in this pull request address the issues described in https://jira.ctmmtrait.nl/browse/FT-1638.
This JIRA ticket describes a number of issues concerning the Logistic Regression function in the Advanced Workflow tab.
- When dragging two categorical concepts into the Outcome box, the help instructions state that the top concept will be mapped the value 1 (success) in the logistic regression algorithm. This is however not enforced by the R code. The concept that is mapped to 1 can not be influenced by the user. And worse, the plot sometimes shows the wrong concept being mapped to 1
- Running an analysis with a binned numeric concept specified as Outcome, renders an error: Unable to complete job wvanderlinden-LogisticRegression-100923: The parameter 'divGroupByVariableType' has not been provided by the client
- A logistic regression analysis using e.g. the expression value of a particular gene in a high dimensional data set as independent variable is not supported. This has been enabled.
- Adding a ROC curve to the analysis results enables users to better assess the predictive power of a logistic regression model.