### PR TITLE
FT-1813 aCGH add homozygous-loss

### DIFF
--- a/web-app/Rscripts/aCGH/acgh-frequency-plot.R
+++ b/web-app/Rscripts/aCGH/acgh-frequency-plot.R
@@ -30,8 +30,9 @@ acgh.frequency.plot <- function
       highdimColumnsMatchingGroupIds <- highdimColumnsMatchingGroupIds[which(!is.na(highdimColumnsMatchingGroupIds))]
       group.calls   <- calls[ , highdimColumnsMatchingGroupIds, drop=FALSE]
 
-      data.info[, paste('gain.freq.', group, sep='')] <- rowSums(group.calls > 0) / ncol(group.calls)
-      data.info[, paste('loss.freq.', group, sep='')] <- rowSums(group.calls < 0) / ncol(group.calls)
+      # We only use the values we know (hom.del, loss, gain, ampl)
+      data.info[, paste('gain.freq.', group, sep='')] <- rowSums(group.calls==1  | group.calls==2 ) / ncol(group.calls)
+      data.info[, paste('loss.freq.', group, sep='')] <- rowSums(group.calls==-1 | group.calls==-2) / ncol(group.calls)
   }
 
   # Replace chromosome X with number 23 to get only integer column values

--- a/web-app/Rscripts/aCGH/acgh-group-test.R
+++ b/web-app/Rscripts/aCGH/acgh-group-test.R
@@ -61,10 +61,9 @@ acgh.group.test <- function
       datacgh <- cbind(datacgh, group.calls)
     }
     group.sizes <- c(group.sizes, length(highdimColumnsMatchingGroupIds))
-    data.info[,paste('loss.freq.', group, sep='')] <- round(rowMeans(group.calls == -1), digits=3)
-    data.info[,paste('gain.freq.', group, sep='')] <- round(rowMeans(group.calls == 1), digits=3)
-    if (2 %in% calls)
-      data.info[,paste('amp.freq.', group, sep='')] <- round(rowMeans(group.calls == 2), digits=3)
+    # We only use known values (-2:hom.los, -1:loss, 1:gain, 2:ampl)
+    data.info[,paste('loss.freq.', group, sep='')] <- round(rowMeans(group.calls==-1 | group.calls==-2), digits=3)
+    data.info[,paste('gain.freq.', group, sep='')] <- round(rowMeans(group.calls==1  | group.calls==2 ), digits=3)
   }
 
   nrcpus=0

--- a/web-app/Rscripts/aCGH/acgh-plot-survival.R
+++ b/web-app/Rscripts/aCGH/acgh-plot-survival.R
@@ -69,6 +69,9 @@ acgh.plot.survival <- function
 
   s <- Surv(phenodata[,survival], phenodata[,status])
   reg <- as.matrix(dat[, grep('^flag\\.', colnames(dat))])
+  # we map the the values -2 and 2 on -1 and 1 respectively
+  reg[reg[] ==  2] <-  1
+  reg[reg[] == -2] <- -1
   if (aberrations == 'gains') {
     reg[reg > 0] <- 1
     reg[reg < 0] <- 0


### PR DESCRIPTION
the aCGH analysis can now also handle HOMOZYGOUS_DELETION values (-2)
In general the following approach is taken:
- "gain" (1) and "ampl" (2) will contribute to gain
- "loss" (-1) and "hom.del" (-2) will contribute to loss
- other values will be ingnored.