### PR TITLE
Fix timepoints for line graph

### DIFF
--- a/web-app/Rscripts/LineGraph/LineGraphLoader.r
+++ b/web-app/Rscripts/LineGraph/LineGraphLoader.r
@@ -33,7 +33,9 @@ LineGraph.loader <- function(
     scaling.data <- data.frame(GROUP = unique(line.data$GROUP), VALUE = 1:length(unique(line.data$GROUP)))
   }
   # assign the X-axis position to each row
-  line.data$TIME_VALUE <- sapply(line.data$GROUP,FUN = function(groupValue) { scaling.data$VALUE[which(groupValue==scaling.data$GROUP)] })
+  line.data$TIME_VALUE <- sapply(line.data$GROUP,FUN = function(groupValue) {
+    scaling.data$VALUE[which(substring(scaling.data$GROUP, nchar(scaling.data$GROUP)-nchar(groupValue)+1)==groupValue)]
+  })
   
   # Either plot a single LineGraph (if there are no plot_group values)
   # or, for each group-value, retrieve rows for that value and plot LineGraph
@@ -102,7 +104,7 @@ LineGraph.plotter <- function(
 	#Use a regular expression trim out the timepoint from the concept.
 	#dataOutput$TIMEPOINT <- str_extract(dataOutput$TIMEPOINT,"Week [0-9]+")
   dataOutput$TIMEPOINT <- as.character(dataOutput$TIMEPOINT)
-  TIMEPOINT_reducedConceptPath <- str_extract(dataOutput$TIMEPOINT,"(\\\\.+\\\\.+\\\\)+?$")
+  TIMEPOINT_reducedConceptPath <- str_extract(dataOutput$TIMEPOINT,"(\\\\[^\\\\]+\\\\[^\\\\]+\\\\)$")
   validReplacements <- which(!is.na(TIMEPOINT_reducedConceptPath))
   dataOutput$TIMEPOINT[validReplacements] <- TIMEPOINT_reducedConceptPath[validReplacements]
   dataOutput$TIMEPOINT <- as.factor(dataOutput$TIMEPOINT)

--- a/web-app/Rscripts/LineGraph/LineGraphLoader.r
+++ b/web-app/Rscripts/LineGraph/LineGraphLoader.r
@@ -30,7 +30,7 @@ LineGraph.loader <- function(
     scaling.data <- read.delim(scaling.filename, header=T, stringsAsFactors = FALSE)
     }
   } else { # if scaling file is not available, each level of group (concept path) will be plotted at the number of that level
-    scaling.data <- data.frame(GROUP = unique(line.data$GROUP), VALUE = 1:length(unique(line.data$GROUP)))
+    scaling.data <- data.frame(GROUP = unique(line.data$GROUP), VALUE = 1:length(unique(line.data$GROUP)), stringsAsFactors = FALSE)
   }
   # assign the X-axis position to each row
   line.data$TIME_VALUE <- sapply(line.data$GROUP,FUN = function(groupValue) {


### PR DESCRIPTION
Rmodules exports data in different format for HDD and LDD in Line Graph analysis.
For HDD it uses category_path as group name, but for LDD it uses shortest unique path. In same time for scaling data it always uses category_path, so it never matches groups from data file and fails with R error.
I tried to implement solution for exporting HDD and LDD in same way, but found it is very hard to find place where it may be changed without affecting other analyses and be sure nothing will be broken. So I decide to localize solution inside `LineGraphLoader.r`. It just matches groups by `endsWith` instead of `equals`. So '\Sex\' will be matched to '\My\Study\Path\Demographics\Sex\' as well as '\Demographics\Sex\' and '\My\Study\Path\Demographics\Sex\' itself. It supports idea of shortest concept paths and works in both scenarios.
I also found error in `TIMEPOINT_reducedConceptPath` calculation - it is always matches full path, because of greedy `.+` regex without character class limitations. As I understand it should only match two latest path components, so I fixed it.